### PR TITLE
cicd: bugfix

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -26,9 +26,9 @@ on:
         default: "run //:license-check"
         type: string
     secrets:
-      gitlab-api-token:
-        description: "Eclipse GitLab API Token for license verification"
-        required: false
+      dash-api-token:
+        description: "Eclipse DASH API Token for license verification"
+        required: true
 
 jobs:
   license-check:
@@ -58,15 +58,9 @@ jobs:
           OUTPUT=""
           EXIT_CODE=0
 
-          # Use org secret as fallback if gitlab-api-token is not provided
-          TOKEN="${{ secrets.gitlab-api-token || secrets.ECLIPSE_GITLAB_API_TOKEN }}"
+          # Use org secret as fallback if dash-api-token is not provided
+          TOKEN="${{ secrets.dash-api-token }}"
           
-          # Fail the job if the secret is not set
-          if [[ -z "$TOKEN" ]]; then
-            echo "ERROR: GitLab API token is missing. Ensure 'ECLIPSE_GITLAB_API_TOKEN' is set as an org secret"
-            exit 1
-          fi
-
           CMD="bazel ${{ inputs.bazel-target }} -- -review -project automotive.score -repo $REPO_URL -token $TOKEN"
           echo "Running: $CMD"
           

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ on:
 
 jobs:
   docs:
-    uses: eclipse-score/ci_cd_repo/.github/workflows/docs.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@main
     with:
       retention-days: 3
 ```
@@ -61,7 +61,7 @@ on:
 
 jobs:
   license-check:
-    uses: eclipse-score/ci_cd_repo/.github/workflows/license-check.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@main
     with:
       repo-url: "${{ github.server_url }}/${{ github.repository }}" # optional, this is the default
       bazel-target: "run //:license-check" # optional, this is the default
@@ -93,7 +93,7 @@ on:
 
 jobs:
   static-analysis:
-    uses: eclipse-score/ci_cd_repo/.github/workflows/static-analysis.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/static-analysis.yml@main
     with:
       bazel-target: "run //:static-analysis" # optional, this is the default
 ```
@@ -121,7 +121,7 @@ on:
 
 jobs:
   tests:
-    uses: eclipse-score/ci_cd_repo/.github/workflows/tests.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/tests.yml@main
 ```
 
 This workflow:
@@ -144,7 +144,7 @@ on:
 
 jobs:
   copyright-check:
-    uses: eclipse-score/ci_cd_repo/.github/workflows/copyright.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main
     with:
       bazel-target: "run //:copyright-check" # optional, this is the default
 ```
@@ -159,9 +159,9 @@ This workflow:
 ---
 
 ##  How to Update Workflows
-Since these workflows are centralized, updates in the `ci_cd_repo` repository will **automatically apply to all repositories using them**. If you need a specific version, reference a **tagged release** instead of `main`:
+Since these workflows are centralized, updates in the `cicd-workflows` repository will **automatically apply to all repositories using them**. If you need a specific version, reference a **tagged release** instead of `main`:
 ```yaml
-uses: eclipse-score/ci_cd_repo/.github/workflows/tests.yml@v1.0.0
+uses: eclipse-score/cicd-workflows/.github/workflows/tests.yml@v1.0.0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
       repo-url: "${{ github.server_url }}/${{ github.repository }}" # optional, this is the default
       bazel-target: "run //:license-check" # optional, this is the default
     secrets:
-      gitlab-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }} #optional
+      dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }} # mandatory - the Eclispe DASH API token 
 ```
 
 This workflow:


### PR DESCRIPTION
Fixed bug caused by misunderstanding.
Even if ECLIPSE_GITLAB_API_TOKEN is set as an organization secret, it won’t be automatically available inside a reusable workflow. Reusable workflows are not automatically given access to secrets from the caller's context ( not even org secrets).

Addresses: eclipse-score/score#813