### PR TITLE
cicd: test target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-name: Tests 
+name: Tests
+
 on:
   workflow_call:
+    inputs:
+      bazel-target:
+        description: "Custom Bazel target to run (e.g.: 'test //src/...')"
+        required: false
+        default: "test //..."
+        type: string
 
 jobs:
   unit-tests:
     name: Test Execution
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
@@ -32,5 +40,7 @@ jobs:
 
       - name: Run Tests via Bazel
         run: |
-          bazel test //...
+          echo "Running: bazel ${{ inputs.bazel-target }}"
+          bazel ${{ inputs.bazel-target }}
+
 


### PR DESCRIPTION
The bazel target has to be made configurable. You don't necessarly want to run tests from all repos, you might want to run them from /src folder for example

Addresses: issue #10