### PR TITLE
cicd: bug

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,6 +105,6 @@ jobs:
 
       - name: Deploy 🚀
         id: pages-deployment
-        uses: ./cicd-workflows/.github/actions/deploy-versioned-pages
+        uses: eclipse-score/cicd-workflows/.github/actions/deploy-versioned-pages@${{ inputs.workflow-version }}
         with:
           source_folder: extracted_docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ on:
         description: "The Bazel target to build (e.g., //docs:github_pages)"
         required: false
         type: string
-        default: "//docs:github-pages"
+        default: "//docs:github_pages"
 
 jobs:
   docs-build:


### PR DESCRIPTION
Default target name as defined by `docs-as-code` is with underscore

Addresses: eclipse-score/module_template#16