### PR TITLE
docs: github limitation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,8 +91,6 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    env:
-      WORKFLOW_VERSION: ${{ inputs.workflow-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
@@ -107,6 +105,6 @@ jobs:
 
       - name: Deploy 🚀
         id: pages-deployment
-        uses: eclipse-score/cicd-workflows/.github/actions/deploy-versioned-pages@${{ env.WORKFLOW_VERSION }}
+        uses: eclipse-score/cicd-workflows/.github/actions/deploy-versioned-pages@main
         with:
           source_folder: extracted_docs


### PR DESCRIPTION
we must hardcode the version in the uses: field for actions. This is a GitHub Actions limitation.

Addresses: eclipse-score/module_template#16