### PR TITLE
cicd: docs

### DIFF
--- a/.github/actions/deploy-versioned-pages/action.yml
+++ b/.github/actions/deploy-versioned-pages/action.yml
@@ -28,6 +28,10 @@ inputs:
   create_comment:
     description: "Create a comment on the PR with the URL to the documentation" # in case of PR
     default: "true"
+  deployment_type:
+    description: "Type of deployment: legacy or workflow"
+    required: false
+    default: "workflow"
 
 outputs:
   target_folder:
@@ -107,6 +111,28 @@ runs:
       with:
         folder: version_root
         clean: false
+
+# Workflow-based GitHub Pages deployment
+    - name: Workflow Configure GitHub Pages
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/configure-pages@v3
+
+    - name: Workflow Checkout gh-pages branch
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: gh-pages-content
+
+    - name: Workflow Upload site artifacts
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: gh-pages-content
+
+    - name: Workflow Deploy site
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/deploy-pages@v4
 
     - name: Find Comment
       if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: "main"
         type: string
+      deployment_type:
+        description: "Type of deployment: legacy or workflow"
+        type: string
+        required: false
+        default: "workflow"
     secrets:
       token:
         description: "GitHub Token"
@@ -81,3 +86,25 @@ jobs:
           branch: gh-pages
           folder: .
           commit-message: "Daily cleanup of outdated documentation"
+
+     # Workflow-based GitHub Pages deployment
+      - name: Workflow Configure GitHub Pages
+        if: ${{ inputs.deployment_type == 'workflow' }}
+        uses: actions/configure-pages@v3
+
+      - name: Workflow Checkout gh-pages branch
+        if: ${{ inputs.deployment_type == 'workflow' }}
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-content
+
+      - name: Workflow Upload site artifacts
+        if: ${{ inputs.deployment_type == 'workflow' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: gh-pages-content
+
+      - name: Workflow Deploy site
+        if: ${{ inputs.deployment_type == 'workflow' }}
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: "//docs:github_pages"
+      deployment_type:
+        description: "Type of deployment: legacy or workflow"
+        type: string
+        required: false
+        default: "workflow"
 
 jobs:
   docs-build:
@@ -159,3 +164,4 @@ jobs:
         uses: eclipse-score/cicd-workflows/.github/actions/deploy-versioned-pages@main
         with:
           source_folder: extracted_docs/html
+          deployment_type: ${{ inputs.deployment_type }}


### PR DESCRIPTION
Enabling publishing GH pages from workflows
It also supports legacy mode.

Our page content can't be dynamically sliced, so it has to be published all together. The content of the gh-pages branch is the single source of truth.

Addresses: #20