### PR TITLE
cicd: clean-up bug

### DIFF
--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       pages: write
       contents: write
+      id-token: write
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4


### PR DESCRIPTION
You must explicitly declare any required permissions in the reusable workflow even if they are already defined in the caller.

Addresses bug: eclipse-score/module_template#27