### PR TITLE
fix: avoid gh-pages worktree conflict by isolating cleanup in subdire…

### DIFF
--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -13,6 +13,11 @@
 
 name: Daily Documentation Cleanup
 
+permissions:
+  contents: write
+  pages:   write
+  id-token: write
+
 on:
   workflow_call:
     inputs:
@@ -46,11 +51,13 @@ jobs:
           repository: ${{ github.repository }}
           ref: gh-pages
           fetch-depth: 0
+          path: gh-pages-cleanup
 
       - name: Install GitHub CLI
         run: sudo apt-get update && sudo apt-get install -y gh jq
 
       - name: Cleanup old documentation
+        working-directory: gh-pages-cleanup
         env:
           GH_TOKEN: ${{ secrets.token }}
         run: |
@@ -85,7 +92,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: .
+          folder: gh-pages-cleanup
           commit-message: "Daily cleanup of outdated documentation"
 
      # Workflow-based GitHub Pages deployment


### PR DESCRIPTION
…ctory

The workflow previously checked out the gh-pages branch into the root directory, which conflicted with the worktree created by the github-pages-deploy-action.

This change moves the checkout to a dedicated `gh-pages-cleanup/` folder, allowing the cleanup logic to operate safely without interfering with deployment steps.

Addresses: #26