### PR TITLE
Disable graphviz cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,7 @@ jobs:
         uses: eclipse-score/apt-install@main
         with:
           packages: graphviz
+          cache: false
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
Disabling the cache in graphviz fixes the plantuml bug. 

See more info here: https://github.com/eclipse-score/docs-as-code/issues/116#issuecomment-3026998493