### PR TITLE
cicd: added reusable workflow for stricter PR reviews

### DIFF
--- a/.github/workflows/required-approvals.yml
+++ b/.github/workflows/required-approvals.yml
@@ -1,0 +1,46 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Required Approvals
+
+on:
+  workflow_call:
+    inputs:
+      min_approvals: { type: number, default: 1, required: false }
+      approval_mode: { type: string, default: ALL, required: false }
+      org_name:      { type: string, default: score, required: false }
+      pat_secret:    { type: string, required: false, description: "Override secret name" }
+
+jobs:
+  check-approvals:
+    runs-on: ${{ vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check for required approvals (CODEOWNERS)
+        id: check-approvals
+        uses: skymoore/required-approvals@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Fallback to SCORE_APPROVALS_PAT if no override is provided
+          read_org_scoped_token: ${{ secrets[inputs.pat_secret] || secrets.SCORE_APPROVALS_PAT }}
+          org_name: ${{ inputs.org_name }}
+          min_approvals: ${{ inputs.min_approvals }}
+          approval_mode: ${{ inputs.approval_mode }}
+          require_all_approvals_latest_commit: true
+
+      - name: Run action if all required approvals are met
+        if: ${{ steps.check-approvals.outputs.approved == 'true' }}
+        run: |
+          echo "✅ All required approvals are met. Proceeding."          

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ These workflows integrate with **Bazel** and provide a consistent way to run **d
 | **Tests**               | Executes tests using GoogleTest, Rust test, or pytest              |
 | **Formatting Check**    | Verifies code formatting using Bazel-based tools                   |
 | **Copyright Check**     | Ensures all source files have the required copyright headers        |
+| **Required Approvals**     | Enforces stricter CODEOWNERS rules for multi-team approvals         |
 
 ---
 
@@ -211,6 +212,49 @@ This workflow:
 > **Default:** `test //:format.check`
 
 ---
+### **8️ Required Approvals Workflow**
+
+This workflow enforces **stricter CODEOWNERS checks** than GitHub’s defaults.  
+Normally, GitHub requires approval from *any one* codeowner when multiple are listed.  
+With this workflow, you can enforce that **all required teams approve** (or set a minimum count).
+
+**Usage Example**
+
+```yaml
+name: Enforce Approvals
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+jobs:
+  enforce:
+    uses: eclipse-score/cicd-workflows/.github/workflows/required-approvals.yml@main
+    with:
+      pat_secret: SCORE_BOT_PAT
+      # Optional overrides:
+      # min_approvals: 2
+      # approval_mode: ALL
+      # org_name: qorix-group
+```
+
+**Defaults**  
+- `org_name`: `score`  
+- `min_approvals`: `1`  
+- `approval_mode`: `ALL`  
+- `require_all_approvals_latest_commit`: always `true`  
+
+**Key Features**  
+✅ Enforces that *all relevant CODEOWNERS* approve (`ALL` mode)  
+✅ Invalidates approvals on new commits (`require_all_approvals_latest_commit`)  
+✅ Works with **org secrets** (e.g. `SCORE_BOT_PAT`) that must have `repo` + `read:org` scopes  
+✅ Compatible with branch protection rules → can be marked as **required**  
+
+---
+
+
 
 ##  How to Update Workflows
 Since these workflows are centralized, updates in the `cicd-workflows` repository will **automatically apply to all repositories using them**. If you need a specific version, reference a **tagged release** instead of `main`:


### PR DESCRIPTION
Add reusable workflow for required approvals.
Introduces required-approvals.yml as a centralized reusable workflow. This enforces stricter CODEOWNERS rules by requiring all designated teams to approve changes, aligning with S-CORE governance practices.

Addresses: eclipse-score/score#1713