### PR TITLE
Skip QNX workflow approval if pull request originates from same repo

### DIFF
--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -71,7 +71,8 @@ jobs:
   approval:
     # If the job is already in the merge queue, the changes have already been reviewed and approved.
     # Thus the approval is already implicit by the review approval.
-    if: github.event_name != 'merge_group'
+    # Also skip approval for same-repository PRs (non-fork contributions).
+    if: github.event_name != 'merge_group' && (!github.event.pull_request || (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name))
     environment: ${{ inputs.environment-name }}
     runs-on: ${{ vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
If the author of the pull request already has write permissions to the repo, he can also approve the QNX workflow. Thus the approval is skipped for convenience.

After merging this the QNX approval workflow should be the same as used in communication. It is implementing this part: https://github.com/eclipse-score/communication/blob/68150892507ed2644d91fb9bfa5e7c513f0e141c/.github/workflows/build_and_test_qnx.yml#L64-L68