### PR TITLE
add generic bazel toolchain job

### DIFF
--- a/.github/workflows/autosd-build.yml
+++ b/.github/workflows/autosd-build.yml
@@ -1,0 +1,95 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: AutoSD Build
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: "Architecture to build"
+        required: false
+        type: string
+        default: "x86_64"
+      runner_label:
+        description: "Runner label to use"
+        required: false
+        type: string
+      bazel-action:
+        description: "Bazel action to run (build, test, etc)"
+        required: false
+        default: "build"
+        type: string
+      bazel-target:
+        description: "Bazel target to build or test"
+        required: false
+        default: "//score/..."
+        type: string
+      bazel-disk-cache:
+        description: "Enable Bazel disk cache on GitHub. The value can be a string to use as cache key for separating workflows"
+        required: false
+        default: "true"
+        type: string
+      extra-bazel-flags:
+        description: "Additional Bazel flags to pass to the build command (whitespace separated)"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  build:
+    name: Build Target
+    runs-on: ${{ inputs.runner_label || (vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS)) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout Repository (Handle all events)
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: odra/cicd-workflows
+          ref: autosd-bazel-ci
+          path: score-ci-cd-workflows
+      - name: Setup Bazel (Shared Caching)
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          disk-cache: ${{ inputs.bazel-disk-cache }}
+          repository-cache: true
+          bazelisk-cache: true
+          cache-save: ${{ github.event_name == 'push' }}
+
+      - name: Look for AutoSD Toolchain
+        run: |
+          bazel cquery '@score_autosd10_x86_64_toolchain//:x86_64-linux-autosd10'
+
+      - name: Check for toolchain bazelrc file
+        run: |
+          stat score-ci-cd-workflows/bazelrc.d/autosd.bazelrc
+
+      - name: Run Bazel Action
+        if: inputs.bazel-target != ''
+        run: |
+          set -euo pipefail
+
+          bazel \
+          --bazelrc=score-ci-cd-workflows/bazelrc.d/autosd.bazelrc \
+          --bazelrc=.bazelrc \
+          ${{ inputs.bazel-action }} \
+          --config autosd-${{ inputs.arch }} \
+          ${{ inputs.extra-bazel-flags }} -- ${{ inputs.bazel-target }}

--- a/bazelrc.d/autosd.bazelrc
+++ b/bazelrc.d/autosd.bazelrc
@@ -1,0 +1,7 @@
+build:autosd-x86_64 --force_pic
+build:autosd-x86_64 --platforms=@score_bazel_platforms//:x86_64-linux-autosd10
+build:autosd-x86_64 --extra_toolchains=@score_autosd10_x86_64_toolchain//:x86_64-linux-autosd10
+
+build:autosd-aarch64 --force_pic
+build:autosd-aarch64 --platforms=@score_bazel_platforms//:aarch64-linux-autosd10
+build:autosd-aarch64 --extra_toolchains=@score_autosd10_aarch64_toolchain//:aarch64-linux-autosd10


### PR DESCRIPTION
## Changes

* adds an autosd workflow to build a Bazel target with a specific config (I think we can be turned in a generic "platform build" job)

## Sample Usage

 ```
name: AutoSD Build
on:
  workflow_dispatch:
  pull_request_target:
    types: [opened, reopened, synchronize]
  merge_group:
    types: [checks_requested]
jobs:
  autosd-build:
    uses: odra/cicd-workflows/.github/workflows/autosd-build.yml@autosd-bazel-ci
    permissions:
      contents: read
      pull-requests: read
    strategy:
      matrix:
        config:
          - autosd-x86_64
    with:
      bazel-target: '//score/...'
      bazel-config: ${{ matrix.config }}
      bazel-disk-cache: ${{ github.workflow }}-${{ github.job }}-${{ matrix.config }}
```

It still requires modules to register toolchains as:

```
module(name = "mymodule")

bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.1")

bazel_dep(name = "platforms", version = "1.0.0")
bazel_dep(name = "score_bazel_platforms", version = "0.1.2")

gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc")

gcc.toolchain(
    name = "score_autosd10_x86_64_toolchain",
    runtime_ecosystem = "autosd10",
    target_cpu = "x86_64",
    target_os = "linux",
    use_default_package = True,
)

use_repo(
    gcc,
    "score_autosd10_x86_64_toolchain"
)

```