### PR TITLE
revert: "fix: Update bazel cache on "merge_group" event (#97)"

### DIFF
--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -38,7 +38,7 @@ jobs:
           disk-cache: false
           repository-cache: false
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Verify MODULE.bazel.lock exists
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -35,7 +35,7 @@ jobs:
           disk-cache: false
           repository-cache: false
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run Copyright Check
         run: |

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -75,7 +75,7 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install lcov (+ bc for threshold check)
         run: |

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -62,7 +62,7 @@ jobs:
           disk-cache: false
           repository-cache: false
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Prepare cache dirs
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,7 +86,7 @@ jobs:
           disk-cache: false
           repository-cache: false
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Prepare cache dirs
         shell: bash

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
           disk-cache: false
           repository-cache: false
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run Formatting Check
         run: |

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -49,7 +49,7 @@ jobs:
           disk-cache: true
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run License Check via Bazel
         run: |

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -105,7 +105,7 @@ jobs:
           disk-cache: ${{ inputs.bazel-disk-cache }}
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Prepare QNX license
         env:

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -74,7 +74,7 @@ jobs:
           disk-cache: true
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run Rust tests with coverage instrumentation
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -45,7 +45,7 @@ jobs:
           disk-cache: true
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run Clippy via Bazel build
         id: bazel-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           disk-cache: true
           repository-cache: true
           bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+          cache-save: ${{ github.event_name == 'push' }}
 
       - name: Run Tests via Bazel
         run: |

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ To improve performance and reduce redundant downloads across workflow runs, the 
     disk-cache: true
     repository-cache: true
     bazelisk-cache: true
-    cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+    cache-save: ${{ github.event_name == 'push' }}
 ```
 
 ### Benefits


### PR DESCRIPTION
This reverts commit ac25d669e392955be86ac87cc7ce3a56e2a6b838.

Github caches are complicated. Pull requests can use a cache that was either created by the same pull request or the main branch. Thus caches created by merge groups will not be used. On top of that each merge group run gets its own temporary branch and thus cache, which will never be reused, but consumes space.

For more information about cache sharing read [this](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache)