### PR TITLE
fix: Only require QNX approval for forks

### DIFF
--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -69,10 +69,10 @@ on:
 
 jobs:
   approval:
+    # Require approvals for PRs from forks, but not for same-repository PRs, merge queues or push events.
     # If the job is already in the merge queue, the changes have already been reviewed and approved.
     # Thus the approval is already implicit by the review approval.
-    # Also skip approval for same-repository PRs (non-fork contributions).
-    if: github.event_name != 'merge_group' && (!github.event.pull_request || (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name))
+    if: github.event_name == 'pull_request_target' && (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
     environment: ${{ inputs.environment-name }}
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
In https://github.com/eclipse-score/inc_someip_gateway we started running workflows after pushes to main, to update the caches. However these require approvals at the moment for QNX workflows.

The approach with whitelisting events, which do not require approvals causes more maintenance. Instead it is easier to specify the event which needs approval.

This way no approvals are needed for merge queues, pushes and same repo pull requests.