### PR TITLE
fix(deploy-versioned-pages): delete stale artifact before upload

### DIFF
--- a/.github/actions/deploy-versioned-pages/action.yml
+++ b/.github/actions/deploy-versioned-pages/action.yml
@@ -138,6 +138,16 @@ runs:
         ref: gh-pages
         path: gh-pages-content
 
+    - name: Delete stale github-pages artifact
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+          --jq '.artifacts[] | select(.name == "github-pages") | .id' | \
+          xargs -r -I{} gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/{}
+
     - name: Workflow Upload site artifacts
       if: ${{ inputs.deployment_type == 'workflow' }}
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

- `actions/deploy-pages` fails if more than one artifact named `github-pages` exists for the same run
- On a manual re-run, each attempt that reaches the upload step creates a new artifact, leaving duplicates from previous attempts
- Adds a step before `actions/upload-pages-artifact` that deletes any pre-existing `github-pages` artifact for the current run

## Root cause

When a workflow run is re-run after a failed deploy, the `docs-build` job uploads a fresh `github-pages-<sha>` artifact (unique name, fine) and the `docs-deploy` job re-uploads the full gh-pages branch as `github-pages` (fixed name). `actions/deploy-pages` requires exactly one artifact with that name and aborts with:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

## Fix

Delete any pre-existing `github-pages` artifact for the run before uploading the new one. The deletion is gated on `deployment_type == 'workflow'` to match the upload step it precedes. `xargs -r` makes it a no-op on the first attempt when no artifact exists yet.

## Test plan

- [x] First-run behaviour unchanged (no artifact to delete, `xargs -r` skips the delete call)
- [ ] Re-run after a failed deploy completes without the duplicate-artifact error