### PR TITLE
chore: disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,9 @@
   onboarding: false,
   requireConfig: "ignored",
 
+  // Disable the dependency dashboard issue
+  dependencyDashboard: false,
+
   // Limit PRs to 10 at a time, to avoid overwhelming maintainers
   prConcurrentLimit: 10,
 


### PR DESCRIPTION
## Summary
- Disables the Renovate dependency dashboard issue across all managed repositories by setting `dependencyDashboard: false` in the shared config.