### PR TITLE
Add more-disk-space action to workflows

### DIFF
--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -66,6 +66,10 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub22_standard_x64 && fromJSON(vars.runner_labels_ghub22_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || inputs.runner-label }}
 
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -38,6 +38,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 3
+
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,6 +77,8 @@ jobs:
           github-app-private-key: ${{ secrets.gh_app_private_key }}
 
       - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 3
 
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -98,6 +98,10 @@ jobs:
       pull-requests: read
 
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
+
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to add a step that increases the available disk space during CI runs. The `eclipse-score/more-disk-space` action is introduced in multiple workflows, each with a specified `level` to control the amount of space reclaimed.

**CI/CD Workflow Improvements:**

* Added the `eclipse-score/more-disk-space` action to the `.github/workflows/cpp-coverage.yml` and `.github/workflows/qnx-build.yml` workflows with `level: 4` to maximize disk space for builds. [[1]](diffhunk://#diff-eaa888fc3a429f7ca944f775f639188c93e29cd8e33e22b145d2071fa6a6604cR69-R72) [[2]](diffhunk://#diff-26f598c9b61dec60c519a0d7d59ee56fd850bda82a913b4060518df57d59ebb2R101-R104)
* Added the `eclipse-score/more-disk-space` action to the `.github/workflows/docs.yml` and `.github/workflows/docs-verify.yml` workflows with `level: 3` to increase available disk space for documentation jobs. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR80-R81) [[2]](diffhunk://#diff-c5f4ace82e6b78805eea12153e19354a2a25cd2498fa1ba46b5d44282a22c5fdR41-R44)