### PR TITLE
feat: Enable linux-sandbox in QNX workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.5.0
+FROM ghcr.io/eclipse-score/devcontainer:v1.6.1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Use Dockerfile to get dependabot version bumps after new image is released
+FROM ghcr.io/eclipse-score/devcontainer:v1.5.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "eclipse-s-core",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -102,6 +102,8 @@ jobs:
         with:
           level: 4
 
+      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock_user_namespace_for_linux_sandbox@add-unblock_user_namespace_for_linux_sandbox
+
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -116,7 +116,7 @@ jobs:
           bazelisk-cache: true
           cache-save: ${{ github.event_name == 'push' }}
 
-      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock-user-namespace-for-linux-sandbox@add-unblock_user_namespace_for_linux_sandbox
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
 
       - name: Setup QNX SDP usage
         uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -102,8 +102,6 @@ jobs:
         with:
           level: 4
 
-      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock-user-namespace-for-linux-sandbox@add-unblock_user_namespace_for_linux_sandbox
-
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -117,6 +115,8 @@ jobs:
           repository-cache: true
           bazelisk-cache: true
           cache-save: ${{ github.event_name == 'push' }}
+
+      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock-user-namespace-for-linux-sandbox@add-unblock_user_namespace_for_linux_sandbox
 
       - name: Setup QNX SDP usage
         uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           level: 4
 
-      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock_user_namespace_for_linux_sandbox@add-unblock_user_namespace_for_linux_sandbox
+      - uses: elektrobit-contrib/eclipse-score_cicd-actions/unblock-user-namespace-for-linux-sandbox@add-unblock_user_namespace_for_linux_sandbox
 
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2


### PR DESCRIPTION
Some tests require that linux-sandbox works. If not they are either unstable or just do not work.

I am currently working on integration tests for inc_someip_gateway. There I need network setup and for tests to be stable (fixed ports used) I either have to serialize test execution or put them into linux-sandbox.

Depends on https://github.com/eclipse-score/cicd-actions/pull/5