### PR TITLE
Add module_template_rollout job in workflow

### DIFF
--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -17,11 +17,6 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
-    inputs:
-      target_repo:
-        description: 'Limit rollout to a single repo (e.g. eclipse-score/score_somemodule). Leave empty to run for all repos.'
-        required: false
-        default: ''
 
 permissions:
   contents: write
@@ -65,7 +60,6 @@ jobs:
       - name: Create PRs to update .bazelversion in all dependent repos
         env:
           GH_TOKEN: ${{ secrets.SCORE_BOT_CLASSIC_PAT }}
-          TARGET_REPO: ${{ github.event.inputs.target_repo || '' }}
         run: |
           set -euo pipefail
 
@@ -78,14 +72,9 @@ jobs:
           echo "Template .bazelversion: $BAZEL_VERSION"
 
           # Find all eclipse-score repos that have a .bazelversion file
-          # If TARGET_REPO is set (manual trigger), only process that one repo
-          if [ -n "$TARGET_REPO" ]; then
-            REPOS="$TARGET_REPO"
-          else
-            REPOS=$(gh search code "filename:.bazelversion" \
-              --owner eclipse-score --limit 100 \
-              --json repository --jq '.[].repository.nameWithOwner' | sort -u)
-          fi
+          REPOS=$(gh search code "filename:.bazelversion" \
+            --owner eclipse-score --limit 100 \
+            --json repository --jq '.[].repository.nameWithOwner' | sort -u)
 
           for repo in $REPOS; do
             [ "$repo" = "$TEMPLATE_REPO" ] && continue

--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -54,7 +54,8 @@ jobs:
     name: Rollout .bazelversion from module_template to all dependent repos
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Create PRs to update .bazelversion in all dependent repos
         env:

--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -65,10 +65,12 @@ jobs:
       - name: Create PRs to update .bazelversion in all dependent repos
         env:
           GH_TOKEN: ${{ secrets.SCORE_BOT_CLASSIC_PAT }}
+          TARGET_REPO: ${{ github.event.inputs.target_repo || '' }}
         run: |
           set -euo pipefail
 
           TEMPLATE_REPO="eclipse-score/module_template"
+          TEMPLATE_DEFAULT_BRANCH=$(gh api "repos/$TEMPLATE_REPO" --jq '.default_branch')
 
           # Read target Bazel version from the template
           BAZEL_VERSION=$(gh api "repos/$TEMPLATE_REPO/contents/.bazelversion" \
@@ -76,9 +78,9 @@ jobs:
           echo "Template .bazelversion: $BAZEL_VERSION"
 
           # Find all eclipse-score repos that have a .bazelversion file
-          # If target_repo is set (manual trigger), only process that one repo
-          if [ -n "${{ inputs.target_repo }}" ]; then
-            REPOS="${{ inputs.target_repo }}"
+          # If TARGET_REPO is set (manual trigger), only process that one repo
+          if [ -n "$TARGET_REPO" ]; then
+            REPOS="$TARGET_REPO"
           else
             REPOS=$(gh search code "filename:.bazelversion" \
               --owner eclipse-score --limit 100 \
@@ -119,7 +121,7 @@ jobs:
             # Create PR (ignore error if one already exists for this branch)
             gh pr create --repo "$repo" \
               --title "chore: update .bazelversion to $BAZEL_VERSION" \
-              --body "Automated rollout of [.bazelversion](https://github.com/$TEMPLATE_REPO/blob/main/.bazelversion) from eclipse-score/module_template. Updates Bazel from \`$current\` to \`$BAZEL_VERSION\`." \
+              --body "Automated rollout of [.bazelversion](https://github.com/$TEMPLATE_REPO/blob/${TEMPLATE_DEFAULT_BRANCH}/.bazelversion) from $TEMPLATE_REPO. Updates Bazel from \`$current\` to \`$BAZEL_VERSION\`." \
               --base "$default_branch" \
               --head "$branch_name" 2>/dev/null || echo "PR already exists for $repo, skipping"
           done

--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -49,3 +49,66 @@ jobs:
           configurationFile: .github/renovate.json5
         env:
           LOG_LEVEL: debug
+
+  module_template_rollout:
+    name: Rollout .bazelversion from module_template to all dependent repos
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Create PRs to update .bazelversion in all dependent repos
+        env:
+          GH_TOKEN: ${{ secrets.SCORE_BOT_CLASSIC_PAT }}
+        run: |
+          set -euo pipefail
+
+          TEMPLATE_REPO="eclipse-score/module_template"
+
+          # Read target Bazel version from the template
+          BAZEL_VERSION=$(gh api "repos/$TEMPLATE_REPO/contents/.bazelversion" \
+            --jq '.content' | base64 --decode | tr -d '[:space:]')
+          echo "Template .bazelversion: $BAZEL_VERSION"
+
+          # Find all eclipse-score repos that have a .bazelversion file
+          REPOS=$(gh search code "filename:.bazelversion" \
+            --owner eclipse-score --limit 100 \
+            --json repository --jq '.[].repository.nameWithOwner' | sort -u)
+
+          for repo in $REPOS; do
+            [ "$repo" = "$TEMPLATE_REPO" ] && continue
+
+            # Fetch the current .bazelversion of this repo
+            response=$(gh api "repos/$repo/contents/.bazelversion" 2>/dev/null) || continue
+            current=$(echo "$response" | jq -r '.content' | base64 --decode | tr -d '[:space:]')
+
+            if [ "$current" = "$BAZEL_VERSION" ]; then
+              echo "$repo: already up to date ($BAZEL_VERSION), skipping"
+              continue
+            fi
+            echo "$repo: updating $current -> $BAZEL_VERSION"
+
+            default_branch=$(gh api "repos/$repo" --jq '.default_branch')
+            branch_name="chore/update-bazelversion-to-${BAZEL_VERSION}"
+
+            # Create branch from default branch (ignore error if it already exists)
+            base_sha=$(gh api "repos/$repo/git/ref/heads/$default_branch" --jq '.object.sha')
+            gh api "repos/$repo/git/refs" -X POST \
+              -f ref="refs/heads/$branch_name" \
+              -f sha="$base_sha" 2>/dev/null || true
+
+            # Commit updated .bazelversion on the branch
+            file_sha=$(gh api "repos/$repo/contents/.bazelversion?ref=$branch_name" --jq '.sha')
+            new_content=$(printf '%s\n' "$BAZEL_VERSION" | base64 -w0)
+            gh api "repos/$repo/contents/.bazelversion" -X PUT \
+              -f message="chore: update .bazelversion to $BAZEL_VERSION" \
+              -f content="$new_content" \
+              -f sha="$file_sha" \
+              -f branch="$branch_name"
+
+            # Create PR (ignore error if one already exists for this branch)
+            gh pr create --repo "$repo" \
+              --title "chore: update .bazelversion to $BAZEL_VERSION" \
+              --body "Automated rollout of [.bazelversion](https://github.com/$TEMPLATE_REPO/blob/main/.bazelversion) from eclipse-score/module_template. Updates Bazel from \`$current\` to \`$BAZEL_VERSION\`." \
+              --base "$default_branch" \
+              --head "$branch_name" 2>/dev/null || echo "PR already exists for $repo, skipping"
+          done

--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -17,6 +17,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'Limit rollout to a single repo (e.g. eclipse-score/score_somemodule). Leave empty to run for all repos.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -71,9 +76,14 @@ jobs:
           echo "Template .bazelversion: $BAZEL_VERSION"
 
           # Find all eclipse-score repos that have a .bazelversion file
-          REPOS=$(gh search code "filename:.bazelversion" \
-            --owner eclipse-score --limit 100 \
-            --json repository --jq '.[].repository.nameWithOwner' | sort -u)
+          # If target_repo is set (manual trigger), only process that one repo
+          if [ -n "${{ inputs.target_repo }}" ]; then
+            REPOS="${{ inputs.target_repo }}"
+          else
+            REPOS=$(gh search code "filename:.bazelversion" \
+              --owner eclipse-score --limit 100 \
+              --json repository --jq '.[].repository.nameWithOwner' | sort -u)
+          fi
 
           for repo in $REPOS; do
             [ "$repo" = "$TEMPLATE_REPO" ] && continue


### PR DESCRIPTION
A new job `module_template_rollout` has been added to `_local_daily.yml`.

### What the job does
Runs daily (and on manual trigger). For each `eclipse-score` repo that has a
`.bazelversion` file:
1. Reads the current `.bazelversion` from `eclipse-score/module_template`
2. Compares it against each repo's version
3. If outdated: creates a branch, commits the updated version, opens a PR

### Testing
Tested manually using `workflow_dispatch` with `target_repo` input, targeting
`qorix-group/reference_integration` (`.bazelversion = 8.4.2`).

The job correctly detected the gap vs template (`8.6.0`) and opened a PR:
→ https://github.com/qorix-group/reference_integration/pull/16