### PR TITLE
formatter: update default bazel target to include error output for formatting check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ on:
       bazel-target:
         description: "Custom Bazel target to run (e.g.: 'test //:format.check')"
         required: false
-        default: "test //:format.check"
+        default: "test --test_output=errors //:format.check"
         type: string
 
 jobs:


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/format.yml` workflow. The change modifies the default Bazel target command to include error output, which will make test errors more visible in CI logs.