### PR TITLE
fix: Do not remove Android SDK from Github runner in QNX workflow

### DIFF
--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
         with:
-          level: 4
+          level: 2
 
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2


### PR DESCRIPTION
`rules_jvm_external` has a dependency on Android SDK, which is required for building QNX.

Other options are:
- Fowngrading rules_jvm_external but that might break any time, when transitive dependencies are bumped: https://github.com/eclipse-score/tooling/pull/297
- Declare `rules_jvm_external` a dev_dependency which will have breaking changes for users of S-CORE tooling.

Tested with https://github.com/eclipse-score/inc_someip_gateway/pull/165