### PR TITLE
fix(docs): prevent concurrent Pages deployments from conflicting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     needs: docs-build
     concurrency:
-      group: pages-deploy-${{ github.repository }}-${{ github.ref }}
+      group: pages-deploy-${{ github.repository }}
       cancel-in-progress: false
     permissions:
       pages: write


### PR DESCRIPTION
Remove github.ref from the docs-deploy concurrency group so all Pages deployments for the same repository serialize. Previously, concurrent runs from different refs (e.g. push to main and pull_request_target) could deploy simultaneously, causing "in progress deployment" errors from deploy-pages.

See https://github.com/eclipse-score/process_description/actions/runs/28446691677/job/84298330778

```
Error: Creating Pages deployment failed
Error: HttpError: Deployment request failed for 068a6468ea77618e9647db6015a5779a849f31f0 due to in progress deployment. Please cancel 8bc38c4750d457aa176585718760675f9e874e06 first or wait for it to complete.
    at /home/runner/work/_actions/actions/deploy-pages/v4/node_modules/@octokit/request/dist-node/index.js:124:1
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:125:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: Failed to create deployment (status: 400) with build version 068a6468ea77618e9647db6015a5779a849f31f0. Request ID B008:173D1E:27962B6:8FC25DC:6A43C05E Responded with: Deployment request failed for 068a6468ea77618e9647db6015a5779a849f31f0 due to in progress deployment. Please cancel 8bc38c4750d457aa176585718760675f9e874e06 first or wait for it to complete.
```