### PR TITLE
fix(docs): queue pending Pages deployments instead of dropping them

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,4 +1,0 @@
-# TODO: Remove once actionlint supports the `queue` key in concurrency sections.
-# See https://github.com/rhysd/actionlint/pull/654
-ignore:
-  - 'unexpected key "queue" for "concurrency" section'

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,4 @@
+# TODO: Remove once actionlint supports the `queue` key in concurrency sections.
+# See https://github.com/rhysd/actionlint/pull/654
+ignore:
+  - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -278,6 +278,7 @@ jobs:
     concurrency:
       group: pages-deploy-${{ github.repository }}
       cancel-in-progress: false
+      queue: max
     permissions:
       pages: write
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,9 @@ repos:
           # Disable shellcheck and pyflakes for now, to enforce consistent behavior.
           - -shellcheck=
           - -pyflakes=
+          # TODO: Remove once actionlint supports the `queue` key (rhysd/actionlint#654)
+          - -ignore
+          - 'unexpected key "queue" for "concurrency" section'
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0
     hooks:


### PR DESCRIPTION
Add queue: max to the docs-deploy concurrency group so that pending runs are queued rather than skipped.