### PR TITLE
ci: Improve bazel caching

### DIFF
--- a/.github/workflows/_local_on_pr.yml
+++ b/.github/workflows/_local_on_pr.yml
@@ -24,3 +24,4 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Check MODULE.bazel formatting
         working-directory: ${{ inputs.working-directory }}
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Verify MODULE.bazel and MODULE.bazel.lock exist
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -66,18 +66,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
-
-      - name: Check MODULE.bazel formatting
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          bazel mod tidy
-          git diff --exit-code
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
   bzlmod-lockfile-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
@@ -95,12 +86,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Verify MODULE.bazel and MODULE.bazel.lock exist
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
+      - name: Check MODULE.bazel formatting
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          bazel mod tidy
+          git diff --exit-code
+
   bzlmod-lockfile-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -52,6 +52,11 @@ on:
 jobs:
   bzlmod-tidy-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Refuse to run on pull_request_target
         if: github.event_name == 'pull_request_target'
@@ -78,6 +83,11 @@ jobs:
 
   bzlmod-lockfile-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Refuse to run on pull_request_target
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -78,5 +78,5 @@ jobs:
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
         uses: eclipse-score/cicd-actions/repository-cache-refresh@use-lurtz-setup-bazel
         with:
-            variants: ${{ inputs.variants }}
+          variants: ${{ inputs.variants }}
           old-caches-json: ${{ env.OLD_CACHES_JSON }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -46,8 +46,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Check if Bazel repository cache inputs changed
         id: check

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -43,8 +43,6 @@ jobs:
     permissions:
       actions: write # needed for cache deletion at setup-bazel-cache
       contents: read
-    env:
-      OLD_CACHES_JSON: ${{ github.workspace }}/.tmp/old_caches.json
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -54,8 +52,6 @@ jobs:
       - name: Check if Bazel repository cache inputs changed
         id: check
         uses: eclipse-score/cicd-actions/repository-cache-check@use-lurtz-setup-bazel
-        with:
-          old-caches-json: ${{ env.OLD_CACHES_JSON }}
 
       - uses: eclipse-score/more-disk-space@v1
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
@@ -105,4 +101,4 @@ jobs:
         uses: eclipse-score/cicd-actions/repository-cache-refresh@use-lurtz-setup-bazel
         with:
           variants: ${{ inputs.variants }}
-          old-caches-json: ${{ env.OLD_CACHES_JSON }}
+          old-caches-json: ${{ steps.check.outputs.old-caches-json }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -25,13 +25,13 @@ on:
     secrets:
       score-qnx-license:
         description: Base64-encoded QNX license content
-        required: true
+        required: false
       score-qnx-user:
         description: QNX account username
-        required: true
+        required: false
       score-qnx-password:
         description: QNX account password
-        required: true
+        required: false
 
 jobs:
   repository_cache_maintenance:
@@ -75,8 +75,24 @@ jobs:
           unique-cache-name: ${{ github.job }}
           skip-cache-restore: true
 
-      - name: Setup QNX SDP usage
+      - name: Check QNX secret availability
+        id: qnx_secrets
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+        shell: bash
+        env:
+          QNX_LICENSE: ${{ secrets.score-qnx-license }}
+          QNX_USER: ${{ secrets.score-qnx-user }}
+          QNX_PASSWORD: ${{ secrets.score-qnx-password }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${QNX_LICENSE}" && -n "${QNX_USER}" && -n "${QNX_PASSWORD}" ]]; then
+            echo "has_all=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_all=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup QNX SDP usage
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' && steps.qnx_secrets.outputs.has_all == 'true' }}
         uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19
         with:
           qnx-license: ${{ secrets.score-qnx-license }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -22,6 +22,16 @@ on:
           forwarded to repository-cache-refresh.
         required: true
         type: string
+    secrets:
+      score-qnx-license:
+        description: Base64-encoded QNX license content
+        required: true
+      score-qnx-user:
+        description: QNX account username
+        required: true
+      score-qnx-password:
+        description: QNX account password
+        required: true
 
 jobs:
   repository_cache_maintenance:
@@ -69,9 +79,9 @@ jobs:
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
         uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19
         with:
-          qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
-          qnx-user: ${{ secrets.SCORE_QNX_USER }}
-          qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
+          qnx-license: ${{ secrets.score-qnx-license }}
+          qnx-user: ${{ secrets.score-qnx-user }}
+          qnx-password: ${{ secrets.score-qnx-password }}
           qnx-license-dir: /opt/score_qnx/license
 
       - name: Refresh Bazel repository cache artifacts

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -69,6 +69,8 @@ jobs:
           unique-cache-name: ${{ github.job }}
           skip-cache-restore: true
 
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
+
       - name: Check QNX secret availability
         id: qnx_secrets
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -1,0 +1,79 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Repository cache maintenance
+
+on:
+  workflow_call:
+
+jobs:
+  repository_cache_maintenance:
+    # Check cache inputs and recreate repository cache only when required.
+    # Fetch dependencies for configured variants and upload a single repository cache.
+    # This job should be the only one which uploads a repository cache.
+    name: Repository cache maintenance
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write # needed for cache deletion at setup-bazel-cache
+      contents: read
+    env:
+      OLD_CACHES_JSON: ${{ github.workspace }}/.tmp/old_caches.json
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check if Bazel repository cache inputs changed
+        id: check
+        uses: eclipse-score/cicd-actions/repository-cache-check@use-lurtz-setup-bazel
+        with:
+          old-caches-json: ${{ env.OLD_CACHES_JSON }}
+
+      - uses: eclipse-score/more-disk-space@v1
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+
+      - name: Create Bazel output base directory
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo mkdir -p /mnt/.bazel
+          sudo chown -R $USER:$USER /mnt/.bazel
+
+      - name: Setup Bazel
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        with:
+          unique-cache-name: ${{ github.job }}
+          skip-cache-restore: true
+
+      - name: Setup QNX SDP usage
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+        uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19
+        with:
+          qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
+          qnx-user: ${{ secrets.SCORE_QNX_USER }}
+          qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
+          qnx-license-dir: /opt/score_qnx/license
+
+      - name: Refresh Bazel repository cache artifacts
+        if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
+        uses: eclipse-score/cicd-actions/repository-cache-refresh@use-lurtz-setup-bazel
+        with:
+          variants: |
+            x86_64-linux|//...
+            aarch64-linux|//...
+            x86_64-qnx|//src/... //tests/...
+            aarch64-qnx|//src/... //tests/...
+          old-caches-json: ${{ env.OLD_CACHES_JSON }}

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -15,6 +15,13 @@ name: Repository cache maintenance
 
 on:
   workflow_call:
+    inputs:
+      variants:
+        description: |-
+          Newline-separated variant specs in the form <platform>|<targets>,
+          forwarded to repository-cache-refresh.
+        required: true
+        type: string
 
 jobs:
   repository_cache_maintenance:
@@ -71,9 +78,5 @@ jobs:
         if: ${{ steps.check.outputs.should_refresh_cache == 'true' }}
         uses: eclipse-score/cicd-actions/repository-cache-refresh@use-lurtz-setup-bazel
         with:
-          variants: |
-            x86_64-linux|//...
-            aarch64-linux|//...
-            x86_64-qnx|//src/... //tests/...
-            aarch64-qnx|//src/... //tests/...
+            variants: ${{ inputs.variants }}
           old-caches-json: ${{ env.OLD_CACHES_JSON }}

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,12 +30,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run Copyright Check
         run: |

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run Copyright Check
         run: |

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -25,6 +25,11 @@ on:
 jobs:
   copyright-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Install lcov (+ bc for threshold check)
         run: |

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -69,12 +69,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Install lcov (+ bc for threshold check)
         run: |

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -54,6 +54,7 @@ on:
 
 permissions:
   contents: read
+  actions: write # needed for cache deletion at setup-bazel-cache
 
 jobs:
   coverage-report:

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -48,51 +48,10 @@ jobs:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - name: Compute cache paths (Linux)
-        id: paths
-        shell: bash
-        run: |
-          BASE="/home/runner/.cache"
-          echo "bazelisk_home=${BASE}/bazelisk" >> "$GITHUB_OUTPUT"
-          echo "output_base=${BASE}/bazel/output_base" >> "$GITHUB_OUTPUT"
-          echo "repo_contents=${BASE}/bazel/repo_contents" >> "$GITHUB_OUTPUT"
-          echo "repo_cache=${BASE}/bazel/repo" >> "$GITHUB_OUTPUT"
-          echo "disk_cache=${BASE}/bazel/disk" >> "$GITHUB_OUTPUT"
-          echo "pip_cache=${BASE}/pip" >> "$GITHUB_OUTPUT"
-
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
-
-      - name: Prepare cache dirs
-        shell: bash
-        run: |
-          mkdir -p \
-            "${{ steps.paths.outputs.bazelisk_home }}" \
-            "${{ steps.paths.outputs.output_base }}" \
-            "${{ steps.paths.outputs.repo_contents }}" \
-            "${{ steps.paths.outputs.repo_cache }}" \
-            "${{ steps.paths.outputs.disk_cache }}" \
-            "${{ steps.paths.outputs.pip_cache }}"
-
-      - name: Restore content cache
-        id: restore-content
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ${{ steps.paths.outputs.bazelisk_home }}
-            ${{ steps.paths.outputs.output_base }}
-            ${{ steps.paths.outputs.repo_contents }}
-            ${{ steps.paths.outputs.repo_cache }}
-            ${{ steps.paths.outputs.disk_cache }}
-            ${{ steps.paths.outputs.pip_cache }}
-          key: ${{ env.CACHE_KEY_PREFIX }}-bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'WORKSPACE*', '.bazelrc*') }}
-          restore-keys: |
-            ${{ env.CACHE_KEY_PREFIX }}-bazel-${{ runner.os }}-
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Install Graphviz
         uses: eclipse-score/apt-install@main
@@ -103,8 +62,4 @@ jobs:
       - name: Run docs verification
         id: verify
         run: |
-          bazel --output_base="${{ steps.paths.outputs.output_base }}" run \
-            --repo_contents_cache="${{ steps.paths.outputs.repo_contents }}" \
-            --repository_cache="${{ steps.paths.outputs.repo_cache }}" \
-            --disk_cache="${{ steps.paths.outputs.disk_cache }}" \
-            ${{ inputs.bazel-docs-verify-target }}
+          bazel ${{ inputs.bazel-docs-verify-target }}

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -49,7 +49,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -49,7 +49,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -49,7 +49,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Bazel
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Install Graphviz
         uses: eclipse-score/apt-install@main

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -37,6 +37,8 @@ jobs:
       verification-result: ${{ steps.verify.outcome }}
     permissions:
       contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -98,124 +98,10 @@ jobs:
           # Reuse the token from inter-repo-access action to ensure access to private repos
           persist-credentials: false
 
-      - name: Compute cache paths (Linux)
-        id: paths
-        shell: bash
-        run: |
-          BASE="/home/runner/.cache"
-          echo "bazelisk_home=${BASE}/bazelisk" >> "$GITHUB_OUTPUT"
-          echo "output_base=${BASE}/bazel/output_base" >> "$GITHUB_OUTPUT"
-          echo "repo_contents=${BASE}/bazel/repo_contents" >> "$GITHUB_OUTPUT"
-          echo "repo_cache=${BASE}/bazel/repo" >> "$GITHUB_OUTPUT"
-          echo "disk_cache=${BASE}/bazel/disk" >> "$GITHUB_OUTPUT"
-          echo "pip_cache=${BASE}/pip" >> "$GITHUB_OUTPUT"
-
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
-
-      - name: Prepare cache dirs
-        shell: bash
-        run: |
-          mkdir -p \
-            "${{ steps.paths.outputs.bazelisk_home }}" \
-            "${{ steps.paths.outputs.output_base }}" \
-            "${{ steps.paths.outputs.repo_contents }}" \
-            "${{ steps.paths.outputs.repo_cache }}" \
-            "${{ steps.paths.outputs.disk_cache }}" \
-            "${{ steps.paths.outputs.pip_cache }}"
-
-      - name: Restore content cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ${{ steps.paths.outputs.bazelisk_home }}
-            ${{ steps.paths.outputs.output_base }}
-            ${{ steps.paths.outputs.repo_contents }}
-            ${{ steps.paths.outputs.repo_cache }}
-            ${{ steps.paths.outputs.disk_cache }}
-            ${{ steps.paths.outputs.pip_cache }}
-          key: ${{ env.CACHE_KEY_PREFIX }}-bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'WORKSPACE*', '.bazelrc*') }}
-          restore-keys: |
-            ${{ env.CACHE_KEY_PREFIX }}-bazel-${{ runner.os }}-
-
-      - name: List cache contents after restore - bazelisk_home
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.bazelisk_home }}" || true
-
-      - name: List cache contents after restore - output_base
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.output_base }}" || true
-
-      - name: List cache contents after restore - repo_contents
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.repo_contents }}" || true
-
-      - name: List cache contents after restore - repo_cache
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.repo_cache }}" || true
-
-      - name: List cache contents after restore - disk_cache
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.disk_cache }}" || true
-
-      - name: List cache contents after restore - pip_cache
-        shell: bash
-        if: runner.debug
-        run: tree -nf -L 3 "${{ steps.paths.outputs.pip_cache }}" || true
-
-      - name: Create cache snapshot (tgz)
-        if: runner.debug
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -uxo pipefail
-
-          ARCHIVE_PATH="$RUNNER_TEMP/cache-snapshot.tgz"
-          entries=()
-          for p in \
-            "${{ steps.paths.outputs.bazelisk_home }}" \
-            "${{ steps.paths.outputs.output_base }}" \
-            "${{ steps.paths.outputs.repo_contents }}" \
-            "${{ steps.paths.outputs.repo_cache }}" \
-            "${{ steps.paths.outputs.disk_cache }}" \
-            "${{ steps.paths.outputs.pip_cache }}"; do
-            if [ -e "$p" ]; then
-              entries+=("${p#/}")
-            else
-              echo "Path does not exist (skipping): $p"
-            fi
-          done
-
-          if [ "${#entries[@]}" -eq 0 ]; then
-            echo "No cache paths found to archive; skipping snapshot creation."
-            exit 0
-          fi
-
-          if ! tar -C / -czf "$ARCHIVE_PATH" "${entries[@]}"; then
-            echo "Cache snapshot creation failed; removing incomplete archive."
-            rm -f "$ARCHIVE_PATH"
-            exit 1
-          fi
-
-      - name: Upload cache snapshot artifact
-        if: runner.debug
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: cache-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/cache-snapshot.tgz
-          retention-days: 5
-          if-no-files-found: ignore
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Install Graphviz
         uses: eclipse-score/apt-install@bd30e2e74a4850389719cb8c3e312bb26aada4e0 # v1.0.0
@@ -241,11 +127,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          bazel --output_base="${{ steps.paths.outputs.output_base }}" run \
-            --repo_contents_cache="${{ steps.paths.outputs.repo_contents }}" \
-            --repository_cache="${{ steps.paths.outputs.repo_cache }}" \
-            --disk_cache="${{ steps.paths.outputs.disk_cache }}" \
-              ${{ inputs.bazel-target }}
+          bazel ${{ inputs.bazel-target }}
 
           tar -cf github-pages.tar _build
 
@@ -256,20 +138,6 @@ jobs:
           path: github-pages.tar
           retention-days: ${{ inputs.retention-days }}
           if-no-files-found: error
-
-      - name: Save content cache (branch)
-        if: success() && github.event_name == 'push'
-        continue-on-error: true
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ${{ steps.paths.outputs.bazelisk_home }}
-            ${{ steps.paths.outputs.output_base }}
-            ${{ steps.paths.outputs.repo_contents }}
-            ${{ steps.paths.outputs.repo_cache }}
-            ${{ steps.paths.outputs.disk_cache }}
-            ${{ steps.paths.outputs.pip_cache }}
-          key: ${{ env.CACHE_KEY_PREFIX }}-bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'WORKSPACE*', '.bazelrc*') }}
 
   docs-deploy:
     name: Deploy Documentation to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Bazel
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Install Graphviz
         uses: eclipse-score/apt-install@bd30e2e74a4850389719cb8c3e312bb26aada4e0 # v1.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bazel
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          bazel ${{ inputs.bazel-target }}
+          bazel run ${{ inputs.bazel-target }}
 
           tar -cf github-pages.tar _build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
     steps:
       - uses: eclipse-score/cicd-actions/inter-repo-access@51883d9cd772bee5b7d139a2e6ffd8aeabca4224 # main branch as of 2026-04-23
         # Hint: if condition cannot access secrets, so we pass them via env

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run Formatting Check
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,12 +29,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run Formatting Check
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,6 +24,11 @@ on:
 jobs:
   format-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run License Check via Bazel
         run: |

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,7 +44,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,12 +44,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run License Check via Bazel
         run: |

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,7 +44,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,7 +44,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      actions: write # needed for cache deletion at setup-bazel-cache
     steps:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -188,12 +188,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: false
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: 🕵️ Detect Bazel targets
         id: detect
@@ -234,12 +231,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: false
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: 🖌️ Run formatting check
         run: bazel test //:format.check
@@ -254,12 +248,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: false
-          repository-cache: false
-          bazelisk-cache: true
-          cache-save: false
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: © Run copyright check
         run: bazel run //:copyright.check

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -190,7 +190,7 @@ jobs:
       - name: ⚙️ Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: 🕵️ Detect Bazel targets
         id: detect
@@ -233,7 +233,7 @@ jobs:
       - name: ⚙️ Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: 🖌️ Run formatting check
         run: bazel test //:format.check
@@ -250,7 +250,7 @@ jobs:
       - name: ⚙️ Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: © Run copyright check
         run: bazel run //:copyright.check

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ⚙️ Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -132,6 +132,9 @@ jobs:
     name: 🔒 Check Bazel Bzlmod lockfile
     needs: detect-repo-capabilities
     if: needs.detect-repo-capabilities.outputs.has_bazel_lock == 'true'
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
     uses: ./.github/workflows/bzlmod-lock-check.yml
 
   bazel-module-name-check:
@@ -182,6 +185,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
 
     steps:
       - name: 📥 Check out
@@ -226,6 +230,11 @@ jobs:
     needs: detect-repo-bazel-targets
     if: needs.detect-repo-bazel-targets.outputs.has_format_check == 'true'
     runs-on: ${{ vars.runner_labels_ghub24_standard_x64 && fromJSON(vars.runner_labels_ghub24_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-24.04' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: 📥 Check out
         uses: actions/checkout@v6
@@ -243,6 +252,11 @@ jobs:
     needs: detect-repo-bazel-targets
     if: needs.detect-repo-bazel-targets.outputs.has_copyright_check == 'true'
     runs-on: ${{ vars.runner_labels_ghub24_standard_x64 && fromJSON(vars.runner_labels_ghub24_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-24.04' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: 📥 Check out
         uses: actions/checkout@v6

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -90,7 +90,7 @@ jobs:
     name: Build QNX target
     # run this job always unless the workflow was canceled; approval may still be skipped by intention
     # Do not use always(), see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (needs.approval.result == 'success' || needs.approval.result == 'skipped') }}
     needs: approval
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -109,7 +109,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -109,12 +109,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 #v0.19.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: ${{ inputs.bazel-disk-cache }}
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -109,7 +109,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -109,7 +109,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
-          unique-cache-name: ${{ github.job }}
+          unique-cache-name: ${{ inputs.bazel-disk-cache }}
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -96,6 +96,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: write # needed for cache deletion at setup-bazel-cache
 
     steps:
       - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run Rust tests with coverage instrumentation
         run: |

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -69,12 +69,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run Rust tests with coverage instrumentation
         run: |

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -61,6 +61,11 @@ jobs:
   rust-coverage:
     name: Rust Coverage
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,12 +40,9 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run Clippy via Bazel build
         id: bazel-build

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run Clippy via Bazel build
         id: bazel-build

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,6 +35,11 @@ jobs:
   static-analysis:
     name: Static Code Analysis
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           cache: false
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
+        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           cache: false
 
       - name: Setup Bazel with shared caching
-        uses: elektrobit-contrib/eclipse-score_cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           cache: false
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
           unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,12 +59,9 @@ jobs:
           cache: false
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@setup-bazel-cache/v0.0.0
         with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
 
       - name: Run Tests via Bazel
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939 # setup-bazel-cache/v0.0.0
         with:
-          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
+          unique-cache-name: ${{ github.job }}
 
       - name: Run Tests via Bazel
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
     name: Test Execution
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 
+    permissions:
+      contents: read
+      actions: write # needed for cache deletion at setup-bazel-cache
+
     steps:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2

--- a/README.md
+++ b/README.md
@@ -627,35 +627,6 @@ uses: eclipse-score/cicd-workflows/.github/workflows/tests.yml@v1.0.0
 
 ---
 
-## ⚡️ Bazel Setup with Shared Caching
-
-To improve performance and reduce redundant downloads across workflow runs, the reusable workflows configure Bazel with shared caching:
-
-```yaml
-- name: Setup Bazel with shared caching
-  uses: bazel-contrib/setup-bazel@0.18.0
-  with:
-    disk-cache: true
-    repository-cache: true
-    bazelisk-cache: true
-    cache-save: ${{ github.event_name == 'push' }}
-```
-
-### Benefits
-
-- **`disk-cache`**: Stores compiled Bazel outputs across jobs.
-- **`repository-cache`**: Caches external dependencies (e.g., modules, WORKSPACE fetches).
-- **`bazelisk-cache`**: Avoids re-downloading Bazel binaries.
-- **`cache-save`**: Saves the cache only on push events to avoid unnecessary cache updates (e.g., from pull requests).
-
-This setup significantly reduces CI build time and improves reuse across different workflows.
-
-
-### **Summary**
-✅ **Standardized** CI/CD workflows across all projects  
-✅ **Reusable & Maintainable** with centralized updates  
-✅ **Bazel-powered** for consistent testing & analysis
-
 ## 🏃‍♂️ Runner Selection Logic
 
 All workflows in this repository use the following logic for selecting the runner:


### PR DESCRIPTION
At the moment the bazel caches can become huge and outdated at the same time. Thus this changes the cache handling as follows:
- repository cache keying is unchanged. However the user repository needs a job, which rebuilds it when especially the `MODULE.bazel.lock` changes. Otherwise it will be incomplete and some jobs still need to download stuff from the internet instead of reusing the cache.
- disk cache keying is changed to a timestamp based one and is unique per job. After each job run an updated cache is pushed.

This requires the presence of a dedicated cache maintenance job. This must at least rebuild the repository cache on `MODULE.bazel.lock` changes. In addition it shall delete the disk caches to ensure their growth is limited and outdated files are removed.