### PR TITLE
feat: pull request and merge queue support for cache-maintenance workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.6.1
+FROM ghcr.io/eclipse-score/devcontainer:v1.8.0

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -26,21 +26,24 @@ name: Repository cache maintenance
 # Both caches are only updated when the workflow is triggered by a push to the main branch.
 # In pull requests and merge_queue the caches are read-only.
 #
+# Concurrency:
+# - Rebuilding caches should not be done in parallel.
+# - Reading caches and dry-runs can be done in parallel.
+#
 # Usage:
-#   This workflow shall be called on pushes to the main branch and in the merge queue and cannot be run with other workflows in parallel, which also make use of bazel caches.
-#   Its purpose is to create a new repository cache and there should not be a race with another job doing the same.
-#   Thus you should have single workflow triggered on pushes to the main branch, which calls this workflow and then your CI workflow.
-#   Once it has finished, jobs using bazels repository cache can be run in parallel.
-#   Running this workflow in the merge queue does not have concurrency issues, because there it is prevented from writing or deleting caches.
+#   This workflow shall be called on pushes to the main branch to rebuild caches if needed.
+#   For dry-runs execute this workflow in pull requests or the merge queue.
 #
 # Example:
 # ```
 # name: Cache maintenance
 
 # on:
-#   workflow_dispatch:
+#   pull_request:
+#     types: [opened, reopened, synchronize, labeled, unlabeled]
 #   merge_group:
 #     types: [checks_requested]
+#   workflow_dispatch:
 #   push:
 #     branches: [main]
 
@@ -63,7 +66,7 @@ name: Repository cache maintenance
 #     needs:
 #       - repository_cache_maintenance
 #     secrets: inherit
-#     if: ${{ !cancelled() }}
+#     if: ${{ github.event_name == 'push' }}
 #     uses: ./.github/workflows/ci.yml
 #
 #   delete_old_caches:
@@ -73,10 +76,10 @@ name: Repository cache maintenance
 #     permissions:
 #       actions: write # needed for deletion of old caches
 #       contents: read
-#     if: ${{ !cancelled() }}
+#     if: ${{ !cancelled() && github.event_name == 'push' }}
 #     steps:
 #       - name: Prune obsolete Bazel caches
-#         uses: eclipse-score/cicd-actions/prune-cache@8e69f47b45778afd3b0d069c0456184c4ceeffe7
+#         uses: eclipse-score/cicd-actions/prune-cache@<hash>
 # ```
 
 on:
@@ -133,12 +136,12 @@ jobs:
 
       - name: Setup Bazel
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
           skip-cache-restore: true
 
-      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@af1be61755b13c1f33b6c250080dc6ac025012f1
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
 
       - name: Check QNX secret availability
@@ -159,7 +162,7 @@ jobs:
 
       - name: Setup QNX SDP usage
         if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' && steps.qnx_secrets.outputs.has_all == 'true' }}
-        uses: eclipse-score/cicd-actions/setup-qnx-sdp@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-qnx-sdp@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           qnx-license: ${{ secrets.score-qnx-license }}
           qnx-user: ${{ secrets.score-qnx-user }}
@@ -168,7 +171,7 @@ jobs:
 
       - name: Validate variants and warm Bazel repository cache artifacts
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
-        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@add-repository-input-check
+        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           variants: ${{ inputs.variants }}
           dry-run: ${{ github.event_name != 'push' }}
@@ -193,4 +196,4 @@ jobs:
           | jq -r '.[] | select(.key | contains("-disk-")) | .id' \
           | xargs -r -n1 gh cache delete --repo ${{ github.repository }}
       - name: Prune repository cache
-        uses: eclipse-score/cicd-actions/prune-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/prune-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -121,7 +121,7 @@ jobs:
             MODULE.bazel.lock
 
       - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
 
       - name: Create Bazel output base directory
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
@@ -139,11 +139,11 @@ jobs:
           skip-cache-restore: true
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@af1be61755b13c1f33b6c250080dc6ac025012f1
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
 
       - name: Check QNX secret availability
         id: qnx_secrets
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
         shell: bash
         env:
           QNX_LICENSE: ${{ secrets.score-qnx-license }}
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Setup QNX SDP usage
-        if: ${{ steps.check.outputs.any_changed == 'true' && steps.qnx_secrets.outputs.has_all == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' && steps.qnx_secrets.outputs.has_all == 'true' }}
         uses: eclipse-score/cicd-actions/setup-qnx-sdp@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           qnx-license: ${{ secrets.score-qnx-license }}
@@ -186,10 +186,9 @@ jobs:
       actions: write # needed for cache deletion
       contents: read
     needs: repository_cache_maintenance
-    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' }}
+    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' && github.event_name == 'push' }}
     steps:
       - name: Delete all disk caches
-        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -167,7 +167,7 @@ jobs:
           qnx-license-dir: /opt/score_qnx/license
 
       - name: Validate variants and warm Bazel repository cache artifacts
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
         uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@add-repository-input-check
         with:
           variants: ${{ inputs.variants }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -27,9 +27,11 @@ name: Repository cache maintenance
 # In pull requests and merge_queue the caches are read-only.
 #
 # Usage:
-#   This workflow shall be called on pushes to the main branch and cannot be run with other workflows in parallel, which also make use of bazel caches.
+#   This workflow shall be called on pushes to the main branch and in the merge queue and cannot be run with other workflows in parallel, which also make use of bazel caches.
 #   Its purpose is to create a new repository cache and there should not be a race with another job doing the same.
 #   Thus you should have single workflow triggered on pushes to the main branch, which calls this workflow and then your CI workflow.
+#   Once it has finished, jobs using bazels repository cache can be run in parallel.
+#   Running this workflow in the merge queue does not have concurrency issues, because there it is prevented from writing or deleting caches.
 #
 # Example:
 # ```
@@ -37,6 +39,8 @@ name: Repository cache maintenance
 
 # on:
 #   workflow_dispatch:
+#   merge_group:
+#     types: [checks_requested]
 #   push:
 #     branches: [main]
 
@@ -176,7 +180,7 @@ jobs:
       actions: write # needed for cache deletion
       contents: read
     needs: repository_cache_maintenance
-    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' }}
+    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' && github.event_name == 'push' }}
     steps:
       - name: Delete all disk caches
         env:

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -166,79 +166,11 @@ jobs:
           qnx-password: ${{ secrets.score-qnx-password }}
           qnx-license-dir: /opt/score_qnx/license
 
-      - name: Validate variants with Bazel config and query checks
+      - name: Validate repository cache variants
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
-        shell: bash
-        env:
-          VARIANTS: ${{ inputs.variants }}
-        run: |
-          set -euo pipefail
-
-          mapfile -t bazelrc_files < <(find . -type f \( -name '.bazelrc' -o -name '*.bazelrc' -o -name '.bazelrc.*' \))
-
-          if [[ ${#bazelrc_files[@]} -eq 0 ]]; then
-            echo "no .bazelrc files were found for validation" >&2
-            exit 1
-          fi
-
-          line_no=0
-          while IFS= read -r variant_line || [[ -n "$variant_line" ]]; do
-            line_no=$((line_no + 1))
-
-            # Skip empty lines from the multiline input.
-            if [[ -z "${variant_line//[[:space:]]/}" ]]; then
-              continue
-            fi
-
-            read -r -a tokens <<< "$variant_line"
-
-            config_arg=""
-            config_count=0
-            targets=()
-
-            for token in "${tokens[@]}"; do
-              if [[ "$token" == --config=* ]]; then
-                config_arg="$token"
-                config_count=$((config_count + 1))
-                continue
-              fi
-
-              if [[ "$token" == --* ]]; then
-                echo "Unsupported option '$token' in variants line $line_no. Only --config=<name> is supported in this workflow input." >&2
-                exit 1
-              fi
-
-              targets+=("$token")
-            done
-
-            if [[ $config_count -gt 1 ]]; then
-              echo "variants line $line_no contains more than one --config=... argument: $variant_line" >&2
-              exit 1
-            fi
-
-            if [[ -n "$config_arg" ]]; then
-              config_name="${config_arg#--config=}"
-              if [[ -z "$config_name" ]]; then
-                echo "variants line $line_no has an empty --config value: $variant_line" >&2
-                exit 1
-              fi
-
-              escaped_config_name="$(printf '%s' "$config_name" | sed -E 's/[][\\.^$*+?(){}|]/\\\\&/g')"
-              if ! grep -E -q "^[[:space:]]*(build|common|fetch|test):${escaped_config_name}([[:space:]]|$)" "${bazelrc_files[@]}"; then
-                echo "Unknown --config=$config_name in variants line $line_no. No matching build/common/fetch/test stanza found in .bazelrc files." >&2
-                exit 1
-              fi
-            fi
-
-            if [[ ${#targets[@]} -eq 0 ]]; then
-              echo "variants line $line_no does not contain a target: $variant_line" >&2
-              exit 1
-            fi
-
-            for target in "${targets[@]}"; do
-              bazel query "$target"
-            done
-          done <<< "$VARIANTS"
+        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache-input-check@add-repository-input-check
+        with:
+          variants: ${{ inputs.variants }}
 
       - name: Warm Bazel repository cache artifacts
         if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -139,7 +139,7 @@ jobs:
           skip-cache-restore: true
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@af1be61755b13c1f33b6c250080dc6ac025012f1
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
 
       - name: Check QNX secret availability
         id: qnx_secrets

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -103,6 +103,11 @@ on:
         description: QNX account password
         required: false
 
+concurrency:
+  # Serialize push and workflow_dispatch runs per branch; keep other events parallel.
+  group: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && format('{0}-{1}', github.workflow, github.ref_name) || format('{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   repository_cache_maintenance:
     name: Create new repository cache if required

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -124,7 +124,7 @@ jobs:
         if: ${{ steps.check.outputs.any_changed == 'true' }}
 
       - name: Create Bazel output base directory
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -132,7 +132,7 @@ jobs:
           sudo chown -R $USER:$USER /mnt/.bazel
 
       - name: Setup Bazel
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
         uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
@@ -167,7 +167,7 @@ jobs:
           qnx-license-dir: /opt/score_qnx/license
 
       - name: Validate variants with Bazel cquery
-        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
         shell: bash
         env:
           VARIANTS: ${{ inputs.variants }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -180,9 +180,10 @@ jobs:
       actions: write # needed for cache deletion
       contents: read
     needs: repository_cache_maintenance
-    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' && github.event_name == 'push' }}
+    if: ${{ needs.repository_cache_maintenance.outputs.should_refresh_cache == 'true' }}
     steps:
       - name: Delete all disk caches
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -166,8 +166,65 @@ jobs:
           qnx-password: ${{ secrets.score-qnx-password }}
           qnx-license-dir: /opt/score_qnx/license
 
-      - name: Warm Bazel repository cache artifacts
+      - name: Validate variants with Bazel cquery
         if: ${{ steps.check.outputs.any_changed == 'true' }}
+        shell: bash
+        env:
+          VARIANTS: ${{ inputs.variants }}
+        run: |
+          set -euo pipefail
+
+          line_no=0
+          while IFS= read -r variant_line || [[ -n "$variant_line" ]]; do
+            line_no=$((line_no + 1))
+
+            # Skip empty lines from the multiline input.
+            if [[ -z "${variant_line//[[:space:]]/}" ]]; then
+              continue
+            fi
+
+            read -r -a tokens <<< "$variant_line"
+
+            config_arg=""
+            config_count=0
+            targets=()
+
+            for token in "${tokens[@]}"; do
+              if [[ "$token" == --config=* ]]; then
+                config_arg="$token"
+                config_count=$((config_count + 1))
+                continue
+              fi
+
+              if [[ "$token" == --* ]]; then
+                echo "Unsupported option '$token' in variants line $line_no. Only --config=<name> is supported in this workflow input." >&2
+                exit 1
+              fi
+
+              targets+=("$token")
+            done
+
+            if [[ $config_count -gt 1 ]]; then
+              echo "variants line $line_no contains more than one --config=... argument: $variant_line" >&2
+              exit 1
+            fi
+
+            if [[ ${#targets[@]} -eq 0 ]]; then
+              echo "variants line $line_no does not contain a target: $variant_line" >&2
+              exit 1
+            fi
+
+            for target in "${targets[@]}"; do
+              if [[ -n "$config_arg" ]]; then
+                bazel cquery "$config_arg" "$target"
+              else
+                bazel cquery "$target"
+              fi
+            done
+          done <<< "$VARIANTS"
+
+      - name: Warm Bazel repository cache artifacts
+        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
         uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           variants: ${{ inputs.variants }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -136,7 +136,7 @@ jobs:
         uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
-          skip-cache-restore: true
+          skip-cache-restore: ${{ github.event_name == 'push' }}
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@af1be61755b13c1f33b6c250080dc6ac025012f1
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -166,17 +166,12 @@ jobs:
           qnx-password: ${{ secrets.score-qnx-password }}
           qnx-license-dir: /opt/score_qnx/license
 
-      - name: Validate repository cache variants
-        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
-        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache-input-check@add-repository-input-check
+      - name: Validate variants and warm Bazel repository cache artifacts
+        if: ${{ steps.check.outputs.any_changed == 'true' }}
+        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@add-repository-input-check
         with:
           variants: ${{ inputs.variants }}
-
-      - name: Warm Bazel repository cache artifacts
-        if: ${{ steps.check.outputs.any_changed == 'true' && github.event_name == 'push' }}
-        uses: eclipse-score/cicd-actions/warm-bazel-repository-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
-        with:
-          variants: ${{ inputs.variants }}
+          dry-run: ${{ github.event_name != 'push' }}
 
   prune_old_caches:
     # Extra job for deletion of caches is needed to avoid time window with no repository cache available.

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -136,10 +136,10 @@ jobs:
         uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
-          skip-cache-restore: ${{ github.event_name == 'push' }}
+          skip-cache-restore: true
 
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@af1be61755b13c1f33b6c250080dc6ac025012f1
-        if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
+        if: ${{ steps.check.outputs.any_changed == 'true' }}
 
       - name: Check QNX secret availability
         id: qnx_secrets

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -166,13 +166,20 @@ jobs:
           qnx-password: ${{ secrets.score-qnx-password }}
           qnx-license-dir: /opt/score_qnx/license
 
-      - name: Validate variants with Bazel cquery
+      - name: Validate variants with Bazel config and query checks
         if: ${{ steps.check.outputs.any_changed == 'true' || github.event_name != 'push' }}
         shell: bash
         env:
           VARIANTS: ${{ inputs.variants }}
         run: |
           set -euo pipefail
+
+          mapfile -t bazelrc_files < <(find . -type f \( -name '.bazelrc' -o -name '*.bazelrc' -o -name '.bazelrc.*' \))
+
+          if [[ ${#bazelrc_files[@]} -eq 0 ]]; then
+            echo "no .bazelrc files were found for validation" >&2
+            exit 1
+          fi
 
           line_no=0
           while IFS= read -r variant_line || [[ -n "$variant_line" ]]; do
@@ -209,17 +216,27 @@ jobs:
               exit 1
             fi
 
+            if [[ -n "$config_arg" ]]; then
+              config_name="${config_arg#--config=}"
+              if [[ -z "$config_name" ]]; then
+                echo "variants line $line_no has an empty --config value: $variant_line" >&2
+                exit 1
+              fi
+
+              escaped_config_name="$(printf '%s' "$config_name" | sed -E 's/[][\\.^$*+?(){}|]/\\\\&/g')"
+              if ! grep -E -q "^[[:space:]]*(build|common|fetch|test):${escaped_config_name}([[:space:]]|$)" "${bazelrc_files[@]}"; then
+                echo "Unknown --config=$config_name in variants line $line_no. No matching build/common/fetch/test stanza found in .bazelrc files." >&2
+                exit 1
+              fi
+            fi
+
             if [[ ${#targets[@]} -eq 0 ]]; then
               echo "variants line $line_no does not contain a target: $variant_line" >&2
               exit 1
             fi
 
             for target in "${targets[@]}"; do
-              if [[ -n "$config_arg" ]]; then
-                bazel cquery "$config_arg" "$target"
-              else
-                bazel cquery "$target"
-              fi
+              bazel query "$target"
             done
           done <<< "$VARIANTS"
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -49,7 +49,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -44,7 +44,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: ⚙️ Setup Bazel with shared caching
         if: ${{ !cancelled() && steps.detect.outputs.has_bazel == 'true' }}
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -109,7 +109,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}${{ inputs.bazel-disk-cache }}
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           cache: false
 
       - name: Setup Bazel with shared caching
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
 


### PR DESCRIPTION
Without pull request / merge queues changes to the workflow or its users are untested before they land on the main branch. This can cause sudden breakage, which we should avoid.

This required bumping cicd-actions to a version with dry-run support.