### PR TITLE
feat(on-pr): provide additional help in logs

### DIFF
--- a/.github/workflows/on-pr.md
+++ b/.github/workflows/on-pr.md
@@ -87,9 +87,16 @@ jobs:
 - **All checks run, even if one fails.** A failing check does not stop the ones
   after it — each reports its own pass/fail, and the job as a whole fails if any
   check failed.
-- **Failures come with guidance.** When a check fails it writes a block to the
-  run's **Summary** page explaining what failed, how to reproduce it locally, and
-  how to fix it — so a red check is actionable without digging through logs.
+- **Failures come with guidance.** When a check fails it explains what failed, how
+  to reproduce it locally, and how to fix it. The same guidance is surfaced in
+  three places so a red check is actionable without hunting: in the **failing
+  step's own log** (what you land on when you click *Details*), as an **error
+  annotation** (PR *Checks* tab and the run's annotations box), and on the run's
+  **Summary** page.
+- **Shared checkout stays clean.** All checks share one checkout, so a check that
+  rewrites files (pre-commit, `bazel mod tidy`) restores the working tree
+  afterwards. Later git-diff-based checks therefore see the original PR state, not
+  the auto-fixed one.
 - **Sequential.** Checks run one after another in a single runner rather than in
   parallel across jobs. This trades a little wall-clock time for far less runner
   spin-up overhead and no skipped-job clutter in the PR checks UI.

--- a/.github/workflows/on-pr.md
+++ b/.github/workflows/on-pr.md
@@ -23,6 +23,7 @@ jobs:
     uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@main
     permissions:
       contents: read
+      pull-requests: write
 ```
 
 That is all that is required. The workflow detects your repository's capabilities
@@ -82,17 +83,38 @@ jobs:
       contents: read
 ```
 
+## Failure reporting
+
+| Input | Default | Behavior |
+| --- | --- | --- |
+| `write-pr-comment` | `true` | Adds each failure's guidance as a PR comment. Comments created by the workflow are removed after a later successful run. |
+| `write-step-summary` | `false` | Adds failure guidance to the GitHub Actions run summary. |
+| `write-annotation` | `false` | Adds a GitHub Actions error annotation for each failure. |
+
+Both reporting options can be changed independently:
+
+```yaml
+jobs:
+  common:
+    uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@main
+    with:
+      write-pr-comment: false
+      write-step-summary: true
+      write-annotation: true
+    permissions:
+      contents: read
+      pull-requests: write
+```
+
 ## Behavior notes
 
 - **All checks run, even if one fails.** A failing check does not stop the ones
   after it — each reports its own pass/fail, and the job as a whole fails if any
   check failed.
 - **Failures come with guidance.** When a check fails it explains what failed, how
-  to reproduce it locally, and how to fix it. The same guidance is surfaced in
-  three places so a red check is actionable without hunting: in the **failing
-  step's own log** (what you land on when you click *Details*), as an **error
-  annotation** (PR *Checks* tab and the run's annotations box), and on the run's
-  **Summary** page.
+  to reproduce it locally, and how to fix it. Guidance is always in the **failing
+  step's own log**. PR comments, error annotations (PR *Checks* tab and the run's
+  annotations box), and the run **Summary** are controlled by the inputs above.
 - **Shared checkout stays clean.** All checks share one checkout, so a check that
   rewrites files (pre-commit, `bazel mod tidy`) restores the working tree
   afterwards. Later git-diff-based checks therefore see the original PR state, not
@@ -109,12 +131,15 @@ jobs:
 
 ## Permissions
 
-No additional permissions required.
-Standard `contents: read` is sufficient for all checks.
+`contents: read` is sufficient for the checks themselves. With the default
+`write-pr-comment: true`, grant `pull-requests: write` so the workflow can add
+and later remove its PR comments. Set `write-pr-comment: false` to keep the
+workflow read-only.
 
 ```yaml
 permissions:
   contents: read
+  pull-requests: write
 ```
 
 ## Runner selection

--- a/.github/workflows/on-pr.md
+++ b/.github/workflows/on-pr.md
@@ -23,7 +23,6 @@ jobs:
     uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@main
     permissions:
       contents: read
-      pull-requests: write
 ```
 
 That is all that is required. The workflow detects your repository's capabilities
@@ -83,38 +82,14 @@ jobs:
       contents: read
 ```
 
-## Failure reporting
-
-| Input | Default | Behavior |
-| --- | --- | --- |
-| `write-pr-comment` | `true` | Adds each failure's guidance as a PR comment. Comments created by the workflow are removed after a later successful run. |
-| `write-step-summary` | `false` | Adds failure guidance to the GitHub Actions run summary. |
-| `write-annotation` | `false` | Adds a GitHub Actions error annotation for each failure. |
-
-Both reporting options can be changed independently:
-
-```yaml
-jobs:
-  common:
-    uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@main
-    with:
-      write-pr-comment: false
-      write-step-summary: true
-      write-annotation: true
-    permissions:
-      contents: read
-      pull-requests: write
-```
-
 ## Behavior notes
 
 - **All checks run, even if one fails.** A failing check does not stop the ones
   after it — each reports its own pass/fail, and the job as a whole fails if any
   check failed.
-- **Failures come with guidance.** When a check fails it explains what failed, how
-  to reproduce it locally, and how to fix it. Guidance is always in the **failing
-  step's own log**. PR comments, error annotations (PR *Checks* tab and the run's
-  annotations box), and the run **Summary** are controlled by the inputs above.
+- **Failures come with guidance.** When a check fails, its own log explains what
+  failed, how to reproduce it locally, and how to fix it. No annotations, run
+  summaries, or PR comments are created.
 - **Shared checkout stays clean.** All checks share one checkout, so a check that
   rewrites files (pre-commit, `bazel mod tidy`) restores the working tree
   afterwards. Later git-diff-based checks therefore see the original PR state, not
@@ -131,15 +106,11 @@ jobs:
 
 ## Permissions
 
-`contents: read` is sufficient for the checks themselves. With the default
-`write-pr-comment: true`, grant `pull-requests: write` so the workflow can add
-and later remove its PR comments. Set `write-pr-comment: false` to keep the
-workflow read-only.
+No additional permissions required. Standard `contents: read` is sufficient.
 
 ```yaml
 permissions:
   contents: read
-  pull-requests: write
 ```
 
 ## Runner selection

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -26,14 +26,15 @@
 # later git-diff-based checks see the original PR state instead of the auto-fixed one.
 #
 # Failing checks report through the shared `report_failure` helper (see the
-# "Prepare failure-reporting helper" step), which surfaces the same guidance in the
-# step log, and optionally as an annotation, on the run's Summary page, and as a
-# PR comment that is removed after a later successful run.
+# "Prepare failure-reporting helper" step), which writes actionable guidance to
+# the failing step's log. Do not duplicate it in step summaries or annotations:
+# both are easy to miss. They do NOT show up on the page that is linked from PRs.
+# And do not write PR comments either: they require write permissions from every
+# caller and cannot reliably be created for fork PRs.
 
 # Attention: this workflow must be called with following permissions:
 #    permissions:
 #      contents: read
-#      pull-requests: write  # only needed when write-pr-comment is true
 
 name: 🔁
 
@@ -65,21 +66,6 @@ on:
         required: false
         default: false
         type: boolean
-      write-pr-comment:
-        description: "Write failure guidance as PR comments and remove those comments after a successful run"
-        required: false
-        default: true
-        type: boolean
-      write-step-summary:
-        description: "Write failure guidance to the GitHub Actions step summary"
-        required: false
-        default: false
-        type: boolean
-      write-annotation:
-        description: "Write a GitHub Actions error annotation for each failure"
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   pr-checks:
@@ -88,7 +74,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: 🚫 Refuse to run on pull_request_target
@@ -105,31 +90,12 @@ jobs:
 
       - name: 🧰 Prepare failure-reporting helper
         if: ${{ !cancelled() }}
-        env:
-          WRITE_PR_COMMENT: ${{ inputs.write-pr-comment }}
-          WRITE_STEP_SUMMARY: ${{ inputs.write-step-summary }}
-          WRITE_ANNOTATION: ${{ inputs.write-annotation }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           # Shared helper sourced by every check below. A failing check calls
           # `report_failure "<title>"` and pipes the Markdown guidance in via a
-          # heredoc. It always writes the guidance to the failing step's log, and
-          # optionally to the PR conversation, as an annotation, and to the step
-          # summary.
+          # heredoc. It writes the guidance to the failing step's log, which is
+          # where the failed check opens when you click "Details".
           cat > "$RUNNER_TEMP/pr-check-lib.sh" <<'LIB'
-          write_pr_comment() {
-            [[ "$WRITE_PR_COMMENT" == "true" && -n "$PR_NUMBER" ]] || return 0
-
-            local comment
-            comment="$(printf '%s\n\n### ❌ %s\n\n%s' '<!-- score-on-pr-failure -->' "$1" "$2")"
-
-            gh api --method POST \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              -f body="$comment" \
-              || echo "::warning::Could not write the PR failure comment. Ensure pull-requests: write is granted."
-          }
-
           report_failure() {
             local title="$1"
             local body
@@ -141,15 +107,7 @@ jobs:
               /[^[:space:]]/ { match($0, /^[[:space:]]*/); if (min == "" || RLENGTH < min) min = RLENGTH }
               END { for (i = 1; i <= NR; i++) print substr(line[i], min + 1) }
             ')"
-            if [[ "$WRITE_ANNOTATION" == "true" ]]; then
-              echo "::error title=${title}::${title}. See this step's log for how to reproduce and fix."
-            fi
             printf '❌ %s\n\n%s\n' "$title" "$body"
-            touch "$RUNNER_TEMP/pr-check-failed"
-            write_pr_comment "$title" "$body"
-            if [[ "$WRITE_STEP_SUMMARY" == "true" ]]; then
-              printf '### ❌ %s\n\n%s\n' "$title" "$body" >> "$GITHUB_STEP_SUMMARY"
-            fi
             exit 1
           }
           LIB
@@ -419,22 +377,3 @@ jobs:
               Regenerate the lockfile with `bazel mod tidy` and commit the updated `MODULE.bazel.lock`.
           MD
           fi
-
-      - name: 🧹 Remove resolved PR failure comments
-        if: ${{ !cancelled() && inputs.write-pr-comment && github.event.pull_request.number }}
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # report_failure leaves this marker behind. Do not remove comments from
-          # a failed run; a later successful run removes only this workflow's
-          # comments.
-          [[ ! -f "$RUNNER_TEMP/pr-check-failed" ]] || exit 0
-
-          comment_ids="$(gh api \
-            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
-            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- score-on-pr-failure -->"))) | .id')"
-
-          for comment_id in $comment_ids; do
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id"
-          done

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -26,7 +26,7 @@
 # later git-diff-based checks see the original PR state instead of the auto-fixed one.
 #
 # Failing checks report through the shared `report_failure` helper (see the
-# "Prepare failure-reporting helper" step), which writes actionable guidance to
+# "Prepare shared check helper" step), which writes actionable guidance to
 # the failing step's log. Do not duplicate it in step summaries or annotations:
 # both are easy to miss. They do NOT show up on the page that is linked from PRs.
 # And do not write PR comments either: they require write permissions from every
@@ -88,7 +88,7 @@ jobs:
       - name: 📥 Check out
         uses: actions/checkout@v6
 
-      - name: 🧰 Prepare failure-reporting helper
+      - name: 🧰 Prepare shared check helper
         if: ${{ !cancelled() }}
         run: |
           # Shared helper sourced by every check below. A failing check calls
@@ -96,6 +96,34 @@ jobs:
           # heredoc. It writes the guidance to the failing step's log, which is
           # where the failed check opens when you click "Details".
           cat > "$RUNNER_TEMP/pr-check-lib.sh" <<'LIB'
+          run_grouped() {
+            local title="$1"
+            shift
+
+            echo "::group::$title"
+            "$@"
+            local status=$?
+            echo "::endgroup::"
+            return "$status"
+          }
+
+          # Runs a boolean-style check function, writes it to GITHUB_OUTPUT and
+          # echoes the result so the detection is visible in the step log.
+          emit_output() {
+            local name="$1"
+            shift
+
+            local value
+            if "$@"; then
+              value=true
+            else
+              value=false
+            fi
+
+            echo "$name=$value" >> "$GITHUB_OUTPUT"
+            echo "  $name=$value"
+          }
+
           report_failure() {
             local title="$1"
             local body
@@ -116,25 +144,9 @@ jobs:
         id: detect
         run: |
           set -euo pipefail
+          source "$RUNNER_TEMP/pr-check-lib.sh"
 
           echo "Detected repository capabilities:"
-
-          # Runs a boolean-style check function, writes it to GITHUB_OUTPUT and
-          # echoes the result so the detection is visible in the step log.
-          emit_output() {
-            local name="$1"
-            shift
-
-            local value
-            if "$@"; then
-              value=true
-            else
-              value=false
-            fi
-
-            echo "$name=$value" >> "$GITHUB_OUTPUT"
-            echo "  $name=$value"
-          }
 
           # Returns success if any provided file path exists.
           any_file_exists() {
@@ -178,11 +190,11 @@ jobs:
         run: |
           source "$RUNNER_TEMP/pr-check-lib.sh"
 
-          if ! uvx pre-commit run --all-files; then
+          if ! run_grouped "pre-commit checks" uvx pre-commit run --all-files; then
             # pre-commit auto-fixes files in place, and only reports failure when it
             # changed something. Restore the working tree so later git-diff-based
             # checks (e.g. `bazel mod tidy`) see the original PR state, not the fixes.
-            git checkout -- .
+            git checkout -- . >/dev/null
             report_failure "pre-commit failed" <<'MD'
               One or more pre-commit hooks reported problems (formatting, linting, etc.).
 
@@ -202,7 +214,7 @@ jobs:
         run: |
           source "$RUNNER_TEMP/pr-check-lib.sh"
 
-          if ! uv run --frozen python -m pytest; then
+          if ! run_grouped "Python tests" uv run --frozen python -m pytest; then
             report_failure "Python tests failed" <<'MD'
               Tests failed, or `uv.lock` is out of date (`--frozen` forbids updating it during the run).
 
@@ -255,25 +267,9 @@ jobs:
         if: ${{ !cancelled() && steps.detect.outputs.has_bazel == 'true' }}
         run: |
           set -euo pipefail
+          source "$RUNNER_TEMP/pr-check-lib.sh"
 
           echo "Detected Bazel targets:"
-
-          # Runs a boolean-style check function, writes it to GITHUB_OUTPUT and
-          # echoes the result so the detection is visible in the step log.
-          emit_output() {
-            local name="$1"
-            shift
-
-            local value
-            if "$@"; then
-              value=true
-            else
-              value=false
-            fi
-
-            echo "$name=$value" >> "$GITHUB_OUTPUT"
-            echo "  $name=$value"
-          }
 
           # Returns success if the given Bazel label can be queried from the repo root.
           has_bazel_target() {
@@ -288,7 +284,7 @@ jobs:
         run: |
           source "$RUNNER_TEMP/pr-check-lib.sh"
 
-          if ! bazel test //:format.check; then
+          if ! run_grouped "bazel test //:format.check" bazel test //:format.check; then
             report_failure "Formatting check failed" <<'MD'
               `//:format.check` found files that are not formatted according to the project formatting rules.
 
@@ -310,7 +306,7 @@ jobs:
         run: |
           source "$RUNNER_TEMP/pr-check-lib.sh"
 
-          if ! bazel run //:copyright.check; then
+          if ! run_grouped "bazel run //:copyright.check" bazel run //:copyright.check; then
             report_failure "Copyright check failed" <<'MD'
               One or more source files are missing the required copyright/license header.
 
@@ -332,10 +328,16 @@ jobs:
         run: |
           source "$RUNNER_TEMP/pr-check-lib.sh"
 
-          if ! { bazel mod tidy && git diff --exit-code; }; then
+          if ! (
+            echo "::group::bazel mod tidy and lockfile diff"
+            bazel mod tidy && git diff --exit-code
+            status=$?
+            echo "::endgroup::"
+            exit "$status"
+          ); then
             # bazel mod tidy rewrites MODULE.bazel / MODULE.bazel.lock in place;
             # restore them so the lockfile check below sees the original PR state.
-            git checkout -- .
+            git checkout -- . >/dev/null
             report_failure "Bazel module is not tidy" <<'MD'
               `bazel mod tidy` would change `MODULE.bazel` or `MODULE.bazel.lock`, so they are not tidy.
 
@@ -364,7 +366,7 @@ jobs:
             exit 1
           fi
 
-          if ! bazel mod deps --lockfile_mode=error; then
+          if ! run_grouped "bazel mod deps --lockfile_mode=error" bazel mod deps --lockfile_mode=error; then
             report_failure "Bazel lockfile is out of date" <<'MD'
               `MODULE.bazel.lock` does not match the resolved dependency graph.
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -20,6 +20,14 @@
 #     pass/fail), while the job as a whole still fails if any step failed.
 # `checkout` and the detection steps keep the default `success()` gate, so if they fail
 # the capability outputs are empty and every check is skipped while the job is red.
+#
+# Because all checks share ONE checkout, a check that rewrites files (pre-commit,
+# `bazel mod tidy`) restores the working tree afterwards with `git checkout -- .`, so
+# later git-diff-based checks see the original PR state instead of the auto-fixed one.
+#
+# Failing checks report through the shared `report_failure` helper (see the
+# "Prepare failure-reporting helper" step), which surfaces the same guidance in the
+# step log, as an annotation, and on the run's Summary page.
 
 # Attention: this workflow must be called with following permissions:
 #    permissions:
@@ -76,6 +84,35 @@ jobs:
 
       - name: 📥 Check out
         uses: actions/checkout@v6
+
+      - name: 🧰 Prepare failure-reporting helper
+        if: ${{ !cancelled() }}
+        run: |
+          # Shared helper sourced by every check below. A failing check calls
+          # `report_failure "<title>"` and pipes the Markdown guidance in via a
+          # heredoc. It surfaces that guidance in three places so a red check is
+          # actionable without hunting:
+          #   1. an ::error annotation (PR "Checks" tab + the run's annotations box),
+          #   2. the failing step's own log (shown first when you click "Details"),
+          #   3. the run's Summary page (rendered Markdown).
+          cat > "$RUNNER_TEMP/pr-check-lib.sh" <<'LIB'
+          report_failure() {
+            local title="$1"
+            local body
+            # Read the heredoc body from stdin and strip the indentation shared by
+            # all non-blank lines, so callers can indent the Markdown block for
+            # readability without it being rendered as a code block (4+ spaces).
+            body="$(awk '
+              { line[NR] = $0 }
+              /[^[:space:]]/ { match($0, /^[[:space:]]*/); if (min == "" || RLENGTH < min) min = RLENGTH }
+              END { for (i = 1; i <= NR; i++) print substr(line[i], min + 1) }
+            ')"
+            echo "::error title=${title}::${title}. See this step's log for how to reproduce and fix."
+            printf '❌ %s\n\n%s\n' "$title" "$body"
+            printf '### ❌ %s\n\n%s\n' "$title" "$body" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+          LIB
 
       - name: 🕵️ Detect repository capabilities
         id: detect
@@ -141,42 +178,44 @@ jobs:
       - name: 🧹 Run pre-commit checks
         if: ${{ !cancelled() && steps.detect.outputs.has_precommit == 'true' && !inputs.skip-pre-commit }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if ! uvx pre-commit run --all-files; then
-            {
-              echo '### ❌ pre-commit failed'
-              echo ''
-              echo 'One or more pre-commit hooks reported problems (formatting, linting, etc.).'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'uvx pre-commit run --all-files'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Most hooks auto-fix. Re-run the command above, review the changes it made, then commit them.'
-              echo 'Run `uvx pre-commit install` once to catch this before pushing.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            # pre-commit auto-fixes files in place, and only reports failure when it
+            # changed something. Restore the working tree so later git-diff-based
+            # checks (e.g. `bazel mod tidy`) see the original PR state, not the fixes.
+            git checkout -- .
+            report_failure "pre-commit failed" <<'MD'
+              One or more pre-commit hooks reported problems (formatting, linting, etc.).
+
+              **Reproduce locally**
+              ```bash
+              uvx pre-commit run --all-files
+              ```
+
+              **Fix**
+              Most hooks auto-fix. Re-run the command above, review the changes it made, then commit them.
+              Run `uvx pre-commit install` once to catch this before pushing.
+          MD
           fi
 
       - name: 🐍 Run Python tests with uv
         if: ${{ !cancelled() && steps.detect.outputs.has_python_uv == 'true' && !inputs.skip-python-tests }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if ! uv run --frozen python -m pytest; then
-            {
-              echo '### ❌ Python tests failed'
-              echo ''
-              echo 'Tests failed, or `uv.lock` is out of date (`--frozen` forbids updating it during the run).'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'uv run --frozen python -m pytest'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Fix the failing tests. If the failure is about the lockfile, run `uv lock` and commit the updated `uv.lock`.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            report_failure "Python tests failed" <<'MD'
+              Tests failed, or `uv.lock` is out of date (`--frozen` forbids updating it during the run).
+
+              **Reproduce locally**
+              ```bash
+              uv run --frozen python -m pytest
+              ```
+
+              **Fix**
+              Fix the failing tests. If the failure is about the lockfile, run `uv lock` and commit the updated `uv.lock`.
+          MD
           fi
 
       - name: 📝 Check Bazel module name
@@ -249,72 +288,74 @@ jobs:
       - name: 🖌️ Run bazel //:format.check
         if: ${{ !cancelled() && steps.bazel.outputs.has_format_check == 'true' && !inputs.skip-format }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if ! bazel test //:format.check; then
-            {
-              echo '### ❌ Formatting check failed'
-              echo ''
-              echo '`//:format.check` found files that are not formatted according to the project formatting rules.'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'bazel test //:format.check'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Auto-format the sources, then commit:'
-              echo '```bash'
-              echo 'bazel run //:format'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            report_failure "Formatting check failed" <<'MD'
+              `//:format.check` found files that are not formatted according to the project formatting rules.
+
+              **Reproduce locally**
+              ```bash
+              bazel test //:format.check
+              ```
+
+              **Fix**
+              Auto-format the sources, then commit:
+              ```bash
+              bazel run //:format
+              ```
+          MD
           fi
 
       - name: © Run bazel //:copyright.check
         if: ${{ !cancelled() && steps.bazel.outputs.has_copyright_check == 'true' && !inputs.skip-copyright }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if ! bazel run //:copyright.check; then
-            {
-              echo '### ❌ Copyright check failed'
-              echo ''
-              echo 'One or more source files are missing the required copyright/license header.'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'bazel run //:copyright.check'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Add the missing headers automatically, then commit:'
-              echo '```bash'
-              echo 'bazel run //:copyright.fix'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            report_failure "Copyright check failed" <<'MD'
+              One or more source files are missing the required copyright/license header.
+
+              **Reproduce locally**
+              ```bash
+              bazel run //:copyright.check
+              ```
+
+              **Fix**
+              Add the missing headers automatically, then commit:
+              ```bash
+              bazel run //:copyright.fix
+              ```
+          MD
           fi
 
       - name: 🔒 Check Bazel module is tidy
         if: ${{ !cancelled() && steps.detect.outputs.has_bazel_lock == 'true' && !inputs.skip-bzlmod-lock }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if ! { bazel mod tidy && git diff --exit-code; }; then
-            {
-              echo '### ❌ Bazel module is not tidy'
-              echo ''
-              echo '`bazel mod tidy` would change `MODULE.bazel` or `MODULE.bazel.lock`, so they are not tidy.'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'bazel mod tidy && git diff'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Run `bazel mod tidy` and commit the resulting changes to `MODULE.bazel` / `MODULE.bazel.lock`.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            # bazel mod tidy rewrites MODULE.bazel / MODULE.bazel.lock in place;
+            # restore them so the lockfile check below sees the original PR state.
+            git checkout -- .
+            report_failure "Bazel module is not tidy" <<'MD'
+              `bazel mod tidy` would change `MODULE.bazel` or `MODULE.bazel.lock`, so they are not tidy.
+
+              **Reproduce locally**
+              ```bash
+              bazel mod tidy && git diff
+              ```
+
+              **Fix**
+              Run `bazel mod tidy` and commit the resulting changes to `MODULE.bazel` / `MODULE.bazel.lock`.
+          MD
           fi
 
       - name: 🔒 Check Bazel lockfile is up to date
         if: ${{ !cancelled() && steps.detect.outputs.has_bazel_lock == 'true' && !inputs.skip-bzlmod-lock }}
         run: |
+          source "$RUNNER_TEMP/pr-check-lib.sh"
+
           if [ ! -f "MODULE.bazel" ]; then
             echo "MODULE.bazel not found in $PWD"
             exit 1
@@ -326,18 +367,15 @@ jobs:
           fi
 
           if ! bazel mod deps --lockfile_mode=error; then
-            {
-              echo '### ❌ Bazel lockfile is out of date'
-              echo ''
-              echo '`MODULE.bazel.lock` does not match the resolved dependency graph.'
-              echo ''
-              echo '**Reproduce locally**'
-              echo '```bash'
-              echo 'bazel mod deps --lockfile_mode=error'
-              echo '```'
-              echo ''
-              echo '**Fix**'
-              echo 'Regenerate the lockfile with `bazel mod tidy` and commit the updated `MODULE.bazel.lock`.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            report_failure "Bazel lockfile is out of date" <<'MD'
+              `MODULE.bazel.lock` does not match the resolved dependency graph.
+
+              **Reproduce locally**
+              ```bash
+              bazel mod deps --lockfile_mode=error
+              ```
+
+              **Fix**
+              Regenerate the lockfile with `bazel mod tidy` and commit the updated `MODULE.bazel.lock`.
+          MD
           fi

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -86,7 +86,7 @@ jobs:
           exit 1
 
       - name: 📥 Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧰 Prepare shared check helper
         if: ${{ !cancelled() }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: ⚙️ Setup uv
         if: ${{ !cancelled() && (steps.detect.outputs.has_precommit == 'true' || steps.detect.outputs.has_python_uv == 'true') }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: 🧹 Run pre-commit checks
         if: ${{ !cancelled() && steps.detect.outputs.has_precommit == 'true' && !inputs.skip-pre-commit }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -27,11 +27,13 @@
 #
 # Failing checks report through the shared `report_failure` helper (see the
 # "Prepare failure-reporting helper" step), which surfaces the same guidance in the
-# step log, as an annotation, and on the run's Summary page.
+# step log, and optionally as an annotation, on the run's Summary page, and as a
+# PR comment that is removed after a later successful run.
 
 # Attention: this workflow must be called with following permissions:
 #    permissions:
 #      contents: read
+#      pull-requests: write  # only needed when write-pr-comment is true
 
 name: 🔁
 
@@ -63,6 +65,21 @@ on:
         required: false
         default: false
         type: boolean
+      write-pr-comment:
+        description: "Write failure guidance as PR comments and remove those comments after a successful run"
+        required: false
+        default: true
+        type: boolean
+      write-step-summary:
+        description: "Write failure guidance to the GitHub Actions step summary"
+        required: false
+        default: false
+        type: boolean
+      write-annotation:
+        description: "Write a GitHub Actions error annotation for each failure"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   pr-checks:
@@ -71,6 +88,7 @@ jobs:
 
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: 🚫 Refuse to run on pull_request_target
@@ -87,15 +105,31 @@ jobs:
 
       - name: 🧰 Prepare failure-reporting helper
         if: ${{ !cancelled() }}
+        env:
+          WRITE_PR_COMMENT: ${{ inputs.write-pr-comment }}
+          WRITE_STEP_SUMMARY: ${{ inputs.write-step-summary }}
+          WRITE_ANNOTATION: ${{ inputs.write-annotation }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Shared helper sourced by every check below. A failing check calls
           # `report_failure "<title>"` and pipes the Markdown guidance in via a
-          # heredoc. It surfaces that guidance in three places so a red check is
-          # actionable without hunting:
-          #   1. an ::error annotation (PR "Checks" tab + the run's annotations box),
-          #   2. the failing step's own log (shown first when you click "Details"),
-          #   3. the run's Summary page (rendered Markdown).
+          # heredoc. It always writes the guidance to the failing step's log, and
+          # optionally to the PR conversation, as an annotation, and to the step
+          # summary.
           cat > "$RUNNER_TEMP/pr-check-lib.sh" <<'LIB'
+          write_pr_comment() {
+            [[ "$WRITE_PR_COMMENT" == "true" && -n "$PR_NUMBER" ]] || return 0
+
+            local comment
+            comment="$(printf '%s\n\n### ❌ %s\n\n%s' '<!-- score-on-pr-failure -->' "$1" "$2")"
+
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -f body="$comment" \
+              || echo "::warning::Could not write the PR failure comment. Ensure pull-requests: write is granted."
+          }
+
           report_failure() {
             local title="$1"
             local body
@@ -107,9 +141,15 @@ jobs:
               /[^[:space:]]/ { match($0, /^[[:space:]]*/); if (min == "" || RLENGTH < min) min = RLENGTH }
               END { for (i = 1; i <= NR; i++) print substr(line[i], min + 1) }
             ')"
-            echo "::error title=${title}::${title}. See this step's log for how to reproduce and fix."
+            if [[ "$WRITE_ANNOTATION" == "true" ]]; then
+              echo "::error title=${title}::${title}. See this step's log for how to reproduce and fix."
+            fi
             printf '❌ %s\n\n%s\n' "$title" "$body"
-            printf '### ❌ %s\n\n%s\n' "$title" "$body" >> "$GITHUB_STEP_SUMMARY"
+            touch "$RUNNER_TEMP/pr-check-failed"
+            write_pr_comment "$title" "$body"
+            if [[ "$WRITE_STEP_SUMMARY" == "true" ]]; then
+              printf '### ❌ %s\n\n%s\n' "$title" "$body" >> "$GITHUB_STEP_SUMMARY"
+            fi
             exit 1
           }
           LIB
@@ -379,3 +419,22 @@ jobs:
               Regenerate the lockfile with `bazel mod tidy` and commit the updated `MODULE.bazel.lock`.
           MD
           fi
+
+      - name: 🧹 Remove resolved PR failure comments
+        if: ${{ !cancelled() && inputs.write-pr-comment && github.event.pull_request.number }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # report_failure leaves this marker behind. Do not remove comments from
+          # a failed run; a later successful run removes only this workflow's
+          # comments.
+          [[ ! -f "$RUNNER_TEMP/pr-check-failed" ]] || exit 0
+
+          comment_ids="$(gh api \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- score-on-pr-failure -->"))) | .id')"
+
+          for comment_id in $comment_ids; do
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id"
+          done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,6 @@ repos:
           # TODO: Remove once actionlint supports the `queue` key (rhysd/actionlint#654)
           - -ignore
           - 'unexpected key "queue" for "concurrency" section'
-
-
-
-
-
-
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
           # TODO: Remove once actionlint supports the `queue` key (rhysd/actionlint#654)
           - -ignore
           - 'unexpected key "queue" for "concurrency" section'
+
+
+
+
+
+
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0
     hooks:


### PR DESCRIPTION
We already had a print of additional help, but it seems step summaries of reusable workflows are quite well hidden under "Summary" :-(

<img width="814" height="592" alt="image" src="https://github.com/user-attachments/assets/0e11f1e8-60b8-4e92-ae14-08242ba97a76" />

This PR provides the very same output in pure logs. Neither annotations nor github comments have worked out.

<img width="739" height="393" alt="image" src="https://github.com/user-attachments/assets/accababe-cbae-4f33-bf0b-b54a79c04c2c" />
