### PR TITLE
Adding the lifcycle repo for eclipse-bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,7 @@
     "eclipse-score/inc_someip_gateway",
     "eclipse-score/infrastructure",
     "eclipse-score/itf",
+    "eclipse-score/lifecycle",
     "eclipse-score/logging",
     "eclipse-score/module_template",
     "eclipse-score/os_images",


### PR DESCRIPTION
Fixes [323](https://github.com/eclipse-score/lifecycle/issues/323)

Adding lifecycle to the list of repos for the eclipse-bot to make automatic dependency update PRs.
The Bazel mod lock job already on lifecycle repo https://github.com/eclipse-score/lifecycle/blob/78ddf713d85398ab3680f2150c50cbd5639dc956/.github/workflows/bzlmod-lock.yml