### PR TITLE
chore(qnx-build): bump checkout action

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.6.1
+FROM ghcr.io/eclipse-score/devcontainer:v1.8.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,12 @@
     "name": "eclipse-s-core",
     "build": {
         "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "github.vscode-github-actions"
+            ]
+        }
     }
 }

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -107,7 +107,8 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          # this job is gated by the approval job
+          # This job is gated by the approval job.
+          # A reviewer must validate the content before approving the workflow.
           allow-unsafe-pr-checkout: true
 
       - name: Setup Bazel with shared caching

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -107,6 +107,8 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # this job is gated by the approval job
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -103,7 +103,7 @@ jobs:
           level: 2
 
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
`actions/checkout` got a security update and should be bumped.

I tried to make the QNX workflow run with the `pull_request` trigger from forks, but in that case there is no access to any secrets at all. This left me with `pull_request_target` as the only option. However I recommend to have the QNX workflow as opt-in via labels in pull requests and to run it in the merge queue. Most of the time the merge queue is enough.

Using labels and workflow approval as a double opt-in should hopefully act as a strong enough safeguard.

More reading:
- https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
- https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout

This PR also bumps the devcontainer image version and add the Github Action extension as an easy drive-by fix.