### PR TITLE
Revert "chore(deps): bump actions/checkout from 4 to 7"

### DIFF
--- a/.github/workflows/_local_daily.yml
+++ b/.github/workflows/_local_daily.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout config file
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run renovate
         uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200 # v46.1.20

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -63,7 +63,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75
@@ -90,7 +90,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -116,7 +116,7 @@ jobs:
       should_refresh_cache: ${{ steps.check.outputs.any_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with: # configuration needed for tj-actions/changed-files
           fetch-depth: 2 # needed for push events
           persist-credentials: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
             build-mode: manual
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -66,7 +66,7 @@ jobs:
           level: 4
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -41,14 +41,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository root for deploy context
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
           ref: gh-pages
           fetch-depth: 0
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
           ref: gh-pages

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -43,7 +43,7 @@ jobs:
           level: 3
 
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,7 +81,7 @@ jobs:
           level: 3
 
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -89,7 +89,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout action
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # current repo name
           repository: eclipse-score/cicd-workflows
@@ -206,7 +206,7 @@ jobs:
             echo "gh-pages branch exists. Skipping creation."
           fi
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download documentation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -38,7 +38,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -75,7 +75,7 @@ jobs:
           exit 1
 
       - name: 📥 Check out
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: 🕵️ Detect repository capabilities
         id: detect

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/score-pr-checks.yml
+++ b/.github/workflows/score-pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Check MODULE.bazel and validate module name
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false # 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository (Handle all events)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
Reverts eclipse-score/cicd-workflows#148

No time for deep investigation at the moment, simply revert change to pull_request_target problems as addressed by @lurtz in #148 review.