### PR TITLE
coverage fix

### DIFF
--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -88,7 +88,12 @@ jobs:
           set -euo pipefail
           set -f  # disable globbing
 
-          cmd=(bazel coverage)
+          # --build_tests_only: restrict building to test targets that pass the
+          # test filters. Without it, wildcard patterns build even filtered-out
+          # tests (e.g. --test_lang_filters=-rust,-miri still BUILDS Miri test
+          # targets, whose Miri-sysroot compiles fail under coverage
+          # instrumentation). See issue #164.
+          cmd=(bazel coverage --build_tests_only)
 
           if [[ -n "${BAZEL_CONFIG}" ]]; then
             cmd+=(--config="${BAZEL_CONFIG}")

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -76,8 +76,14 @@ jobs:
       - name: Run Rust tests with coverage instrumentation
         run: |
           set -euo pipefail
-          echo "Running: bazel test ${{ inputs.bazel-test-config-flags }} ${{ inputs.bazel-test-args }} ${{ inputs.bazel-test-targets }}"
-          bazel test ${{ inputs.bazel-test-config-flags }} ${{ inputs.bazel-test-args }} ${{ inputs.bazel-test-targets }}
+          # --build_tests_only: restrict building to test targets that pass the
+          # test filters, so consumers' --test_lang_filters/--test_tag_filters
+          # also exclude filtered tests from BUILDING. Without it, wildcard
+          # patterns build even filtered-out tests (e.g. Miri targets, whose
+          # Miri-sysroot compiles fail when coverage instrumentation is
+          # enabled). See issue #164.
+          echo "Running: bazel test --build_tests_only ${{ inputs.bazel-test-config-flags }} ${{ inputs.bazel-test-args }} ${{ inputs.bazel-test-targets }}"
+          bazel test --build_tests_only ${{ inputs.bazel-test-config-flags }} ${{ inputs.bazel-test-args }} ${{ inputs.bazel-test-targets }}
 
       - name: Generate coverage reports
         run: |


### PR DESCRIPTION
pass --build_tests_only to bazel coverage

    Test language/tag filters only control which tests RUN - with wildcard
    target patterns, bazel coverage still BUILDS filtered-out test targets.
    This broke consumers with Miri tests once score_toolchains_rust 0.9.2
    enabled Rust coverage instrumentation: the Miri test subgraph is
    compiled against the Miri sysroot, which does not ship the
    profiler_builtins crate that instrumented compiles require
    (error[E0463], aborting the whole coverage invocation and killing
    in-flight C++ tests).

    With --build_tests_only the filters apply to building as well, so
    excluded tests are neither run nor built. Verified on
    eclipse-score/lifecycle#369: without the flag the job fails at 16/19
    tests; with it, exit 0 and 19/19 tests pass.****