### PR TITLE
Enable LFS in checkouts

### DIFF
--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75
@@ -91,6 +93,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -117,7 +117,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with: # configuration needed for tj-actions/changed-files
+        with:
+          lfs: true
+          # configuration needed for tj-actions/changed-files
           fetch-depth: 2 # needed for push events
           persist-credentials: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # Reuse the token from inter-repo-access action to ensure access to private repos

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: 📥 Check out
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: 🕵️ Detect repository capabilities
         id: detect

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # This job is gated by the approval job.

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 

--- a/.github/workflows/score-pr-checks.yml
+++ b/.github/workflows/score-pr-checks.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Check MODULE.bazel and validate module name
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          lfs: true
 
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@44248a21e169b7513b78c12d7b1a800323bb7b75

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:
+          lfs: true
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 


### PR DESCRIPTION
When workflows are used in some downstream repos
as reusable element, and those repos uses lfs
this option have to be set. For non lfs repos
it does not have any impact