### PR TITLE
fix: Restore deploy-versioned-pages actions

### DIFF
--- a/.github/actions/deploy-versioned-pages/action.yml
+++ b/.github/actions/deploy-versioned-pages/action.yml
@@ -1,0 +1,169 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Deploy Versioned Pages
+description: Will push the documentation to the gh-pages branch, possibly with a versioned URL. When the PR is closed, the documentation will be deleted.
+# Note: this has some shortcomings, like race conditions when multiple PRs are opened at the same time,
+# problems with overwriting existing files, not deleting deleted files, etc.
+# We'll address these when we transform this action into a truly reusable independent action.
+# But for now, let's get it working!
+#
+# Concurrency note:
+#   This action previously used softprops/turnstyle@v3 to serialize deployments. turnstyle relies
+#   on github.workflow to look up the workflow ID and list runs. When this composite action is
+#   invoked via workflow_call, github.workflow resolves to the top-level caller's workflow name
+#   rather than the reusable workflow's filename, causing turnstyle to fail to find matching runs.
+#   This is a known incompatibility between turnstyle and nested reusable workflows.
+#
+#   The fix is to use GitHub's native concurrency key on the calling job instead:
+#     concurrency:
+#       group: pages-deploy-${{ github.repository }}-${{ github.ref }}
+#       cancel-in-progress: false
+#   This works correctly regardless of workflow nesting depth.
+
+inputs:
+  source_folder:
+    description: "Path to the html files to deploy in current working directory"
+    required: true
+  versions_file:
+    description: "Path to the versions file on gh-pages branch"
+    default: "versions.json"
+  create_comment:
+    description: "Create a comment on the PR with the URL to the documentation" # in case of PR
+    default: "true"
+  deployment_type:
+    description: "Type of deployment: legacy or workflow"
+    required: false
+    default: "workflow"
+
+outputs:
+  target_folder:
+    description: "The target folder for the documentation"
+    value: ${{ steps.calc.outputs.target_folder }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Determine target_folder
+      id: calc
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == 'pull_request_target' || "${{ github.event_name }}" == 'pull_request' ]]; then
+          target_folder="pr-${{ github.event.pull_request.number }}"
+        elif [[ "${{ github.event_name }}" == 'release' ]]; then
+          target_folder="${{ github.event.release.tag_name }}"
+        else
+          target_folder="${{github.ref_name}}"
+        fi
+        echo "target_folder=$target_folder" >> $GITHUB_OUTPUT
+
+    - name: Prepare the deploy folder
+      shell: bash
+      run: |
+        # Prepare the deploy folder
+        mkdir -p deploy_root
+        mkdir -p version_root
+        # Move the files to the deploy folder
+        mv ${{ inputs.source_folder }}/* deploy_root/
+        # Ensure that the folder is not treated as a Jekyll site
+        touch deploy_root/.nojekyll
+
+        # Add the target folder to the versions file
+        BASE_REPO="${{ github.server_url }}/${{ github.repository }}.git"
+
+        echo "Fetching gh-pages from BASE_REPO: $BASE_REPO"
+        git remote add base "$BASE_REPO" || git remote set-url base "$BASE_REPO"
+        git fetch base gh-pages --depth 1
+
+        # Checkout only the versions file from gh-pages branch of the base repo
+        # If the file doesn't exist yet (first deployment), initialize with an empty array
+        git checkout base/gh-pages -- "${{ inputs.versions_file }}" \
+          || { echo "versions file not found on gh-pages, initializing empty"; echo '[]' > "${{ inputs.versions_file }}"; }
+
+        target="${{ steps.calc.outputs.target_folder }}"
+        new_version="${{ steps.calc.outputs.target_folder }}"
+
+        if jq -e --arg version "$new_version" 'map(select(.version == $version)) | length > 0' "${{ inputs.versions_file }}" > /dev/null; then
+          echo "Version '$new_version' already exists in ${{ inputs.versions_file }}"
+        else
+          REPO_NAME=$(basename ${{ github.repository }})
+          USER_NAME=$(echo ${{ github.repository }} | cut -d'/' -f1)
+          GITHUB_PAGES_URL="https://${USER_NAME}.github.io/${REPO_NAME}"
+          if [ "$target" = "/" ]; then
+            new_url="${GITHUB_PAGES_URL}/"
+          else
+            new_url="${GITHUB_PAGES_URL}/$target/"
+          fi
+
+          jq --arg version "$new_version" --arg url "$new_url" '. + [{"version": $version, "url": $url}]' "${{ inputs.versions_file }}" > tmp_versions.json
+          mv tmp_versions.json "${{ inputs.versions_file }}"
+        fi
+        mv "${{ inputs.versions_file }}" version_root/
+        ls -al .
+        ls -al deploy_root
+        ls -al version_root
+        cat  version_root/"${{ inputs.versions_file }}"
+
+    - name: Deploy Documentation
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: deploy_root
+        target-folder: ${{ steps.calc.outputs.target_folder }}
+        clean: true
+        clean-exclude: .nojekyll
+
+    - name: Deploy  version file 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: version_root
+        clean: false
+
+    - name: Workflow Configure GitHub Pages
+      # Workflow-based GitHub Pages deployment
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/configure-pages@v3
+
+    - name: Workflow Checkout gh-pages branch
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: gh-pages-content
+
+    - name: Workflow Upload site artifacts
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: gh-pages-content
+
+    - name: Workflow Deploy site
+      if: ${{ inputs.deployment_type == 'workflow' }}
+      uses: actions/deploy-pages@v4
+
+    - name: Find Comment
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: The created documentation from the pull request
+
+    - name: Comment on PR with docs URL
+      if: ${{ github.event_name == 'pull_request_target' && inputs.create_comment == 'true' && steps.fc.outputs.comment-id == '' }}
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{github.event.pull_request.number}}
+        body: |
+          The created documentation from the pull request is available at: [docu-html](https://${{ github.event.repository.owner.login }}.github.io/${{ github.event.repository.name }}/${{ steps.calc.outputs.target_folder }})
+        reactions: rocket


### PR DESCRIPTION
The old docs workflow uses this action @main and now fails. Due the use of `pull_request_target` this makes even switching to the new docs workflow impossible. Thus restore it until all users are migrated.

Caused by https://github.com/eclipse-score/cicd-workflows/pull/124