### PR TITLE
fix: support direct docs publishing

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -55,7 +55,9 @@ concurrency:
 jobs:
   docs-deploy:
     name: Deploy documentation to GitHub Pages
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name != 'workflow_run' && github.repository_owner != 'eclipse-score')
     permissions:
       actions: read # download the artifact produced by the triggering workflow run
       pages: write # publish to GitHub Pages
@@ -69,10 +71,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login || '' }}
-          EVENT_NAME: ${{ github.event.workflow_run.event }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
-          REF_NAME: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login || github.event.pull_request.head.repo.owner.login || '' }}
+          EVENT_NAME: ${{ github.event.workflow_run.event || github.event_name }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || '' }}
+          REF_NAME: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "pull_request_target" ]]; then
             # fork-origin workflow_run payloads do not include pull_requests[];
@@ -202,7 +204,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: github-pages
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
           github-token: ${{ github.token }}
           path: gh-pages-content/${{ steps.target.outputs.folder }}
 

--- a/.github/workflows/docs.md
+++ b/.github/workflows/docs.md
@@ -5,7 +5,7 @@ The documentation workflow is split into two stages:
 1. `docs.yml` builds documentation in the unprivileged pull request or push
    workflow and uploads a `github-pages` artifact.
 2. `docs-publish.yml` runs after a successful build, retrieves that artifact,
-   and publishes it to GitHub Pages with the required write permissions.
+  and publishes it to GitHub Pages with the required write permissions.
 
 Keeping the build and publishing stages separate prevents untrusted pull request
 code from running with repository write permissions.
@@ -48,7 +48,7 @@ on:
     types: [completed]
 
 jobs:
-  docs-deploy:
+  docs-publish:
     if: github.event.workflow_run.conclusion == 'success'
     uses: eclipse-score/cicd-workflows/.github/workflows/docs-publish.yml@main
     with:
@@ -65,6 +65,32 @@ jobs:
 
 The value in `workflows` must exactly match the build workflow's `name`.
 Merge-queue builds are validated but not published.
+
+## Trusted internal repositories
+
+Repositories that do not accept fork-origin pull requests may run build and
+publish as dependent jobs in the same workflow. This direct configuration is
+not permitted for repositories owned by `eclipse-score`.
+
+```yaml
+jobs:
+  docs:
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@main
+  docs-publish:
+    needs: docs
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-publish.yml@main
+    with:
+      # Omit for GitHub Actions Pages deployments. Set to "legacy" when
+      # GitHub Pages is configured to publish from the gh-pages branch.
+      deployment_type: workflow
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      pages: write
+      pull-requests: write
+```
+
 For repositories using the legacy "Deploy from a branch" Pages source, set
 `deployment_type: legacy`; the workflow updates `gh-pages` but does not run the
 GitHub Actions Pages deployment.


### PR DESCRIPTION
## Why

`docs-publish.yml` is reusable via `workflow_call`, but it read all metadata and the artifact run ID from `github.event.workflow_run`. When a consumer calls it directly after its documentation build, that object is absent and the deploy job is skipped even after a successful build.

## What

Support both supported invocation contexts. `workflow_run` invocations retain their successful-build gate and source-run metadata. Direct invocations fall back to the caller event, ref, pull request, and `github.run_id`, allowing a single trusted workflow to build and publish documentation.

The usage guide now shows the direct configuration and calls out that it is appropriate only where pull request code may receive write permissions.

## Changes

- `.github/workflows/docs-publish.yml`: resolve deployment metadata and artifact run ID from the caller when no `workflow_run` payload exists.
- `.github/workflows/docs.md`: document the single-workflow usage and its permission boundary.