### PR TITLE
fix(docs): prevent Pages artifact collisions

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -58,6 +58,9 @@ jobs:
     if: >-
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name != 'workflow_run' && github.repository_owner != 'eclipse-score')
+    env:
+      # Avoid collisions with the build artifact and with prior job retries.
+      PAGES_ARTIFACT_NAME: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       actions: read # download the artifact produced by the triggering workflow run
       pages: write # publish to GitHub Pages
@@ -255,12 +258,15 @@ jobs:
         if: steps.metadata.outputs.should_deploy == 'true'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
+          name: ${{ env.PAGES_ARTIFACT_NAME }}
           path: gh-pages-content
 
       - name: Deploy artifact to GitHub Pages
         if: steps.metadata.outputs.should_deploy == 'true' && inputs.deployment_type != 'legacy'
         id: deploy-pages
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}
 
       - name: Find existing PR comment
         if: steps.metadata.outputs.should_deploy == 'true' && steps.metadata.outputs.pr_number != ''


### PR DESCRIPTION
## Summary

- use a Pages artifact name that is unique to each workflow run attempt
- pass the same name to `deploy-pages`
- avoid collisions with the documentation build artifact and prior job retries

Fixes #182