### PR TITLE
add disk cleanup step

### DIFF
--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -62,6 +62,8 @@ jobs:
           echo "Use pull_request or schedule instead."
           exit 1
 
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
         with:
@@ -90,6 +92,8 @@ jobs:
           echo "making it unsafe to run bazel on untrusted input."
           echo "Use pull_request or schedule instead."
           exit 1
+
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
 
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,8 @@ jobs:
           - language: c-cpp
             build-mode: manual
     steps:
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,6 +25,8 @@ jobs:
   format-check:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -97,6 +97,8 @@ jobs:
           echo "Use pull_request or merge_group instead."
           exit 1
 
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: 📥 Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -62,6 +62,8 @@ jobs:
     name: Rust Coverage
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -36,6 +36,8 @@ jobs:
     name: Static Code Analysis
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 
     steps:
+      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
LLVM toolchain takes a lot of space and fails to download due to space limit in formatting workflow.

Adding more-space step also to other workflows as prevention for the future.