### PR TITLE
fix: preserve open documentation previews

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -82,5 +82,6 @@ jobs:
     uses: ./.github/workflows/docs-cleanup.yml
     permissions:
       contents: write
+      pull-requests: read
       pages: write
       id-token: write

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -15,6 +15,7 @@ name: Daily Documentation Cleanup
 
 permissions:
   contents: write
+  pull-requests: read
   pages: write
   id-token: write
 
@@ -38,6 +39,7 @@ jobs:
     permissions:
       pages: write
       contents: write
+      pull-requests: read
       id-token: write
     steps:
       - name: Checkout repository root for deploy context
@@ -63,10 +65,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           gh auth status
 
           ACTIVE_BRANCHES=$(gh api --paginate repos/${{ github.repository }}/branches --jq '.[].name')
-          OPEN_PRS=$(gh api --paginate repos/${{ github.repository }}/pulls --jq '.[].number' | sed 's/^/pr-/')
+          OPEN_PRS=$(gh api --paginate repos/${{ github.repository }}/pulls --jq '.[] | "pr-\(.number)"')
           TAGS=$(gh api --paginate repos/${{ github.repository }}/tags --jq '.[].name')
           VALID_ENTRIES=$(echo -e "$ACTIVE_BRANCHES\n$OPEN_PRS\n$TAGS")
           CURRENT_FOLDERS=$(find . -maxdepth 1 -type d -not -name '.' -not -path './.*' -exec basename {} \;)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary

- pass `pull-requests: read` through the daily maintenance call chain
- grant the cleanup job permission to list open pull requests
- abort cleanup on API or pipeline failures instead of treating an empty result as authoritative
- document the permission for direct users of the deprecated cleanup workflow

## Problem

The cleanup workflow determines valid `pr-*` previews by listing open pull requests. Releases v0.0.1 and v0.0.2 omit the required permission and pipe the API call through `sed` without `pipefail`. If the API request fails, `sed` still exits successfully, `OPEN_PRS` becomes empty, and active previews can be deleted while the job remains green.

The same implementation is currently consumed through daily maintenance by `eclipse-score/score`, `eclipse-score/docs-as-code`, and `eclipse-score/inc_diagnostics`. Sampled runs in these public repositories preserved open previews, but the workflow is not safe for callers where pull-request reads require explicit token permission.
