### PR TITLE
fix(qnx): restore level 4 disk cleanup

### DIFF
--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -103,7 +103,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
+      - uses: eclipse-score/more-disk-space@5ca49359776dab58ce3f7e06f7ac9491bc696aa6 # 2026-08-14
         with:
           level: 4
 

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: eclipse-score/more-disk-space@3fac5780033e636b114cf69e891dc19d640855c2 # v1.1
         with:
-          level: 2
+          level: 4
 
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1


### PR DESCRIPTION
## Summary

- restore `level: 4` for the QNX disk cleanup step
- pin `eclipse-score/more-disk-space` to the fixed revision
- replace the temporary level-2 configuration while retaining the corrected cleanup behavior