### PR TITLE
fix: Consider all pull requests when creating docs-publish comment

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -85,7 +85,7 @@ jobs:
               PR_NUMBER="$(curl -fsSL \
                 -H "Authorization: Bearer ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${REPO}/pulls?head=${HEAD_REPO_OWNER}:${REF_NAME}" \
+                "https://api.github.com/repos/${REPO}/pulls?state=all&head=${HEAD_REPO_OWNER}:${REF_NAME}" \
                 | jq -r '.[0].number // empty' || true)"
             fi
 

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -85,7 +85,7 @@ jobs:
               PR_NUMBER="$(curl -fsSL \
                 -H "Authorization: Bearer ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${REPO}/pulls?state=open&head=${HEAD_REPO_OWNER}:${REF_NAME}" \
+                "https://api.github.com/repos/${REPO}/pulls?head=${HEAD_REPO_OWNER}:${REF_NAME}" \
                 | jq -r '.[0].number // empty' || true)"
             fi
 


### PR DESCRIPTION
When a pull request from a fork got merged before the docs-publish workflow was started it will fail to find the pull request number. This is caused by filtering open pull requests. Now all are considered.

Example of failing workflow:
- https://github.com/eclipse-score/infrastructure/pull/58
- https://github.com/eclipse-score/infrastructure/actions/runs/32020505175/job/95358999938#step:2:51

The fix should show all pull requests:
- https://api.github.com/repos/eclipse-score/infrastructure/pulls?head=etas-contrib:dependa&state=all