### PR TITLE
Enable linux-sandbox for coverage

### DIFF
--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -51,11 +51,6 @@ on:
         required: false
         default: 0
         type: number
-      linux-sandbox:
-        description: "Configure AppArmor so Bazel's linux-sandbox may create user namespaces (Ubuntu runners only)"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -82,7 +77,6 @@ jobs:
 
       # Needs bazel on PATH: the action resolves `bazel info install_base`.
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@212bbf86267e9381da9d2daf962d12f6feafbc90
-        if: ${{ inputs.linux-sandbox }}
 
       - name: Install lcov (+ bc for threshold check)
         run: |

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -51,6 +51,11 @@ on:
         required: false
         default: 0
         type: number
+      linux-sandbox:
+        description: "Configure AppArmor so Bazel's linux-sandbox may create user namespaces (Ubuntu runners only)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -74,6 +79,10 @@ jobs:
         uses: eclipse-score/cicd-actions/setup-bazel-cache@212bbf86267e9381da9d2daf962d12f6feafbc90
         with:
           unique-cache-name: ${{ github.job }}
+
+      # Needs bazel on PATH: the action resolves `bazel info install_base`.
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@212bbf86267e9381da9d2daf962d12f6feafbc90
+        if: ${{ inputs.linux-sandbox }}
 
       - name: Install lcov (+ bc for threshold check)
         run: |

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -56,11 +56,6 @@ on:
         required: false
         default: 30
         type: number
-      linux-sandbox:
-        description: "Configure AppArmor so Bazel's linux-sandbox may create user namespaces (Ubuntu runners only)"
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   rust-coverage:
@@ -83,7 +78,6 @@ jobs:
 
       # Needs bazel on PATH: the action resolves `bazel info install_base`.
       - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@212bbf86267e9381da9d2daf962d12f6feafbc90
-        if: ${{ inputs.linux-sandbox }}
 
       - name: Run Rust tests with coverage instrumentation
         run: |

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: 30
         type: number
+      linux-sandbox:
+        description: "Configure AppArmor so Bazel's linux-sandbox may create user namespaces (Ubuntu runners only)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   rust-coverage:
@@ -75,6 +80,10 @@ jobs:
         uses: eclipse-score/cicd-actions/setup-bazel-cache@212bbf86267e9381da9d2daf962d12f6feafbc90
         with:
           unique-cache-name: ${{ github.job }}
+
+      # Needs bazel on PATH: the action resolves `bazel info install_base`.
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@212bbf86267e9381da9d2daf962d12f6feafbc90
+        if: ${{ inputs.linux-sandbox }}
 
       - name: Run Rust tests with coverage instrumentation
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           unique-cache-name: ${{ github.job }}
 
+      # Needs bazel on PATH: the action resolves `bazel info install_base`.
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@212bbf86267e9381da9d2daf962d12f6feafbc90
+
       - name: Run Tests via Bazel
         run: |
           set -euo pipefail


### PR DESCRIPTION
Needed in case the tests are using some common locations like /tmp for testing to not collide