### PR TITLE
Allow runs-on labels as input params

### DIFF
--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -48,10 +48,18 @@ on:
         required: false
         default: "."
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   bzlmod-tidy-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Refuse to run on pull_request_target
         if: github.event_name == 'pull_request_target'
@@ -81,7 +89,7 @@ jobs:
           git diff --exit-code
 
   bzlmod-lockfile-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 
     steps:
       - name: Refuse to run on pull_request_target

--- a/.github/workflows/bzlmod-lock-check.yml
+++ b/.github/workflows/bzlmod-lock-check.yml
@@ -51,8 +51,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,10 +20,18 @@ on:
         required: false
         default: "bazel build //..."
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -21,10 +21,18 @@ on:
         required: false
         default: "run //:copyright-check"
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   copyright-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -24,8 +24,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -51,6 +51,14 @@ on:
         required: false
         default: 0
         type: number
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -58,7 +66,7 @@ permissions:
 jobs:
   coverage-report:
     name: C++ Coverage
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 
     steps:
       - uses: eclipse-score/more-disk-space@beee38c3b4426a7c43fdfeb2495d1af812179c3e # v1.3.0

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -54,8 +54,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,11 +19,20 @@ name: Daily Maintenance Tasks
 
 on:
   workflow_call:
+    inputs:
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   stale-prs:
     name: Mark and close stale pull requests
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: write
@@ -51,7 +60,7 @@ jobs:
             are ready, and we will pick it up from there.
   detect-repo-capabilities:
     name: Detect repository capabilities
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: read
       pages: read

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,8 +23,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -27,6 +27,14 @@ on:
         type: string
         required: false
         default: "workflow"
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     secrets:
       token:
         description: "deprecated, not used."
@@ -35,7 +43,7 @@ on:
 jobs:
   docs-cleanup:
     name: Cleanup old documentation
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       pages: write
       contents: write

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -30,8 +30,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -46,6 +46,14 @@ on:
         required: false
         default: "workflow"
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: cicd-pages-deploy
@@ -67,7 +75,7 @@ jobs:
       id-token: write # to verify the deployment originates from an appropriate source
       contents: write # to update versions.json and commit to gh-pages
       pull-requests: write # to comment on PRs with preview link
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Resolve build metadata
         id: metadata

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -49,8 +49,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -21,6 +21,14 @@ on:
         required: false
         type: string
         default: "//:docs_check"
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     outputs:
       verification-result:
         description: "Result of the docs verification"
@@ -32,7 +40,7 @@ env:
 jobs:
   docs-verify:
     name: Docs Verification
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     outputs:
       verification-result: ${{ steps.verify.outcome }}
     permissions:

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -24,8 +24,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,14 @@ on:
         required: false
         default: ""
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     secrets:
       gh_app_private_key:
         description: "GitHub App Private Key for inter-repo access (not used in public S-CORE)"
@@ -55,7 +63,7 @@ env:
 jobs:
   docs-build:
     name: Build Documentation
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,8 +44,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,8 +23,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,10 +20,18 @@ on:
         required: false
         default: "test --test_output=errors //:format.check"
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   format-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - uses: eclipse-score/more-disk-space@beee38c3b4426a7c43fdfeb2495d1af812179c3e # v1.3.0
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -25,6 +25,14 @@ on:
         required: false
         default: "run //:license-check"
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     secrets:
       dash-api-token:
         description: "Eclipse DASH API Token for license verification"
@@ -32,7 +40,7 @@ on:
 
 jobs:
   license-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -28,8 +28,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/on-pr.md
+++ b/.github/workflows/on-pr.md
@@ -148,5 +148,5 @@ permissions:
 ## Runner selection
 
 `on-pr` uses the standard S-CORE runner-label resolution:
-`runner_labels_ghub24_standard_x64` → `REPO_RUNNER_LABELS` → `ubuntu-24.04`. See
+`runner-labels` input → `runner_labels_ghub24_standard_x64` → `REPO_RUNNER_LABELS` → `ubuntu-24.04`. See
 [Runner Selection Logic](../../README.md#️-runner-selection-logic) for details.

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -71,6 +71,14 @@ on:
         required: false
         default: ""
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     secrets:
       github-app-private-key:
         description: GitHub App private key used with `github-app-client-id` to access private Bazel dependencies
@@ -82,7 +90,7 @@ on:
 jobs:
   pr-checks:
     name: 🔁 Common PR checks
-    runs-on: ${{ vars.runner_labels_ghub24_standard_x64 && fromJSON(vars.runner_labels_ghub24_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub24_standard_x64 && fromJSON(vars.runner_labels_ghub24_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-24.04' }}
 
     permissions:
       contents: read

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -74,8 +74,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -76,8 +76,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/qnx-build.yml
+++ b/.github/workflows/qnx-build.yml
@@ -73,6 +73,14 @@ on:
         required: false
         default: 4
         type: number
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
     secrets:
       score-qnx-license:
         description: Base64-encoded QNX license content
@@ -94,7 +102,8 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
     environment: ${{ inputs.environment-name }}
     runs-on: >-
-      ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) ||
+      ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) ||
+      vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) ||
       vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -110,7 +119,8 @@ jobs:
     if: ${{ !cancelled() && (needs.approval.result == 'success' || needs.approval.result == 'skipped') }}
     needs: approval
     runs-on: >-
-      ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) ||
+      ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) ||
+      vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) ||
       vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: read

--- a/.github/workflows/required-approvals.yml
+++ b/.github/workflows/required-approvals.yml
@@ -19,10 +19,18 @@ on:
       approval_mode: {type: string, default: ALL, required: false}
       org_name: {type: string, default: score, required: false}
       pat_secret: {type: string, required: false, description: "Override secret name"}
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   check-approvals:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/required-approvals.yml
+++ b/.github/workflows/required-approvals.yml
@@ -22,8 +22,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -56,11 +56,19 @@ on:
         required: false
         default: 30
         type: number
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   rust-coverage:
     name: Rust Coverage
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - uses: eclipse-score/more-disk-space@beee38c3b4426a7c43fdfeb2495d1af812179c3e # v1.3.0
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -59,8 +59,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/score-pr-checks.yml
+++ b/.github/workflows/score-pr-checks.yml
@@ -19,8 +19,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/score-pr-checks.yml
+++ b/.github/workflows/score-pr-checks.yml
@@ -15,10 +15,19 @@ name: SCORE PR Checks
 
 on:
   workflow_call:
+    inputs:
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   bazel-module-name-check:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,8 +33,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,11 +30,19 @@ on:
         required: false
         default: ""
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   static-analysis:
     name: Static Code Analysis
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
       - uses: eclipse-score/more-disk-space@beee38c3b4426a7c43fdfeb2495d1af812179c3e # v1.3.0
 

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -27,10 +27,18 @@ on:
         description: "Path to the template sync ignore file"
         type: string
         default: ".github/.templatesyncignore"
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   repo-sync:
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -30,8 +30,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,19 @@ on:
         required: false
         default: ""
         type: string
+      runner-labels:
+        description: >-
+          Runner label(s) for this workflow's jobs, overriding the repository/organization runner
+          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
+          '["self-hosted", "linux", "x64"]').
+        required: false
+        default: ""
+        type: string
 
 jobs:
   unit-tests:
     name: Test Execution
-    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 
     steps:
       - uses: eclipse-score/more-disk-space@beee38c3b4426a7c43fdfeb2495d1af812179c3e # v1.3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ on:
       runner-labels:
         description: >-
           Runner label(s) for this workflow's jobs, overriding the repository/organization runner
-          variables. Accepts a single label (e.g. 'self-hosted') or a JSON array of labels (e.g.
-          '["self-hosted", "linux", "x64"]').
+          variables. Must be a JSON-encoded string: a single label as a JSON string (e.g.
+          '"self-hosted"') or a JSON array of labels (e.g. '["self-hosted", "linux", "x64"]').
         required: false
         default: ""
         type: string

--- a/README.md
+++ b/README.md
@@ -664,3 +664,13 @@ following JSON array:
 This allows you to specify multiple labels for your runner, which can be used to match it in the workflow. For example, if you have a self-hosted runner with the labels `self-hosted`, `linux`, `x64`, and `custom-label`, you can set the variable to the above JSON array, and the workflow will use that runner when it runs.
 
 The `runner-labels` workflow input accepts the same syntax (a single string or a JSON array string) and is available on every reusable workflow in this repository that selects its runner via this logic.
+
+> ⚠️ **Caller syntax:** `runner-labels` is a `string` input, and `with:` values for a reusable workflow call only accept scalars — a bare YAML sequence is rejected. Quote the JSON value as a string in the caller:
+>
+> ```yaml
+> with:
+>   runner-labels: '["self-hosted", "linux", "x64"]'   # correct: quoted JSON array
+>   # runner-labels: ["self-hosted", "linux", "x64"]   # WRONG: real YAML sequence, fails schema validation
+> ```
+>
+> For a single label, quote it as a JSON string too: `runner-labels: '"self-hosted"'`.

--- a/README.md
+++ b/README.md
@@ -610,19 +610,20 @@ uses: eclipse-score/cicd-workflows/.github/workflows/tests.yml@v1.0.0
 All workflows in this repository use the following logic for selecting the runner:
 
 ```yaml
-runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+runs-on: ${{ inputs.runner-labels && fromJSON(inputs.runner-labels) || vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
 ```
 
 This means:
 
-- If your repository defines a variable named `runner_labels_ghub_standard_x64` (or any of the other supported ones) or `REPO_RUNNER_LABELS` (e.g., in repository or organization settings), its value will be used as the runner label(s).  
+- If the caller workflow passes a `runner-labels` input when invoking the reusable workflow (`with: runner-labels: ...`), that value is used as the runner label(s).
+- Otherwise, if your repository defines a variable named `runner_labels_ghub_standard_x64` (or any of the other supported ones) or `REPO_RUNNER_LABELS` (e.g., in repository or organization settings), its value will be used as the runner label(s).  
   This allows you to use **self-hosted runners** or any custom runner configuration.
-- If `runner_labels_ghub_standard_x64` or `REPO_RUNNER_LABELS` is **not set**, the workflow will default to GitHub-hosted `ubuntu-latest`.
+- If none of the above are set, the workflow will default to GitHub-hosted `ubuntu-latest`.
 
 **Why?**  
-This approach allows forked repositories or projects with special requirements to use their own runners, while everyone else gets a reliable default.
+This approach allows forked repositories or projects with special requirements to use their own runners, while everyone else gets a reliable default. The `runner-labels` input additionally lets an individual caller override the runner for a single workflow invocation without changing repository/organization-wide variables.
 
-> ℹ️ **Tip:** To use a self-hosted runner, set the `runner_labels_ghub_standard_x64` or `REPO_RUNNER_LABELS` variable in your repository or organization settings to the label(s) of your runner.
+> ℹ️ **Tip:** To use a self-hosted runner, either pass the `runner-labels` input to the workflow call, or set the `runner_labels_ghub_standard_x64` or `REPO_RUNNER_LABELS` variable in your repository or organization settings to the label(s) of your runner.
 
 ### Runner labels variable naming convention
 
@@ -661,3 +662,5 @@ following JSON array:
 ```
 
 This allows you to specify multiple labels for your runner, which can be used to match it in the workflow. For example, if you have a self-hosted runner with the labels `self-hosted`, `linux`, `x64`, and `custom-label`, you can set the variable to the above JSON array, and the workflow will use that runner when it runs.
+
+The `runner-labels` workflow input accepts the same syntax (a single string or a JSON array string) and is available on every reusable workflow in this repository that selects its runner via this logic.


### PR DESCRIPTION
Sometimes You may want to run QNX on 16 core and
doc only on 4 cores ie due to cost handling when
running on internal infra. Until now, its impossible since You can only use single repo label.